### PR TITLE
[DEV-42] 단어 상세 조회 시 좋아요 수와 좋아요 여부 정보 추가

### DIFF
--- a/src/databases/repositories/user.repository.ts
+++ b/src/databases/repositories/user.repository.ts
@@ -3,8 +3,8 @@ import { InjectRepository } from '@nestjs/typeorm';
 
 import { Repository } from 'typeorm';
 
-import { RequestCreateUserDto } from '#/user/dto/create-user.dto';
 import { User } from '#/databases/entities/user.entity';
+import { RequestCreateUserDto } from '#/user/dto/create-user.dto';
 
 @Injectable()
 export class UserRepository {

--- a/src/databases/repositories/word.repository.ts
+++ b/src/databases/repositories/word.repository.ts
@@ -8,7 +8,10 @@ import { PaginationDto, PaginationMetaDto } from '#/common/dto/pagination.dto';
 import { Word } from '#/databases/entities/word.entity';
 import { RequestCreateUserDto } from '#/user/dto/create-user.dto';
 import { RequestUpdateWordDto } from '#/word/dto/update-word.dto';
-import { ResponseWordDetailDto } from '#/word/dto/word-detail.dto';
+import {
+	RequestWordDetailDto,
+	ResponseWordDetailDto,
+} from '#/word/dto/word-detail.dto';
 import {
 	RequestWordListDto,
 	ResponseWordListDto,
@@ -48,7 +51,8 @@ export class WordRepository {
 		return this.wordRepository.findOneBy({ id: wordId });
 	}
 
-	async findByIdWithUserLike(wordId: string, userId?: string) {
+	async findByIdWithUserLike(wordDetailDto: RequestWordDetailDto) {
+		const { wordId, userId } = wordDetailDto;
 		const word = await this.wordRepository
 			.createQueryBuilder('word')
 			.leftJoin('word.likes', 'like')

--- a/src/databases/repositories/word.repository.ts
+++ b/src/databases/repositories/word.repository.ts
@@ -5,8 +5,10 @@ import { plainToInstance } from 'class-transformer';
 import { DataSource, Repository } from 'typeorm';
 
 import { PaginationDto, PaginationMetaDto } from '#/common/dto/pagination.dto';
+import { Word } from '#/databases/entities/word.entity';
 import { RequestCreateUserDto } from '#/user/dto/create-user.dto';
 import { RequestUpdateWordDto } from '#/word/dto/update-word.dto';
+import { ResponseWordDetailDto } from '#/word/dto/word-detail.dto';
 import {
 	RequestWordListDto,
 	ResponseWordListDto,
@@ -19,7 +21,6 @@ import {
 	RequestWordUserLikeDto,
 	ResponseWordUserLikeDto,
 } from '#/word/dto/word-user-like.dto';
-import { Word } from '#/databases/entities/word.entity';
 
 @Injectable()
 export class WordRepository {
@@ -43,8 +44,36 @@ export class WordRepository {
 		return this.wordRepository.findOneBy({ name });
 	}
 
-	findById(id: string) {
-		return this.wordRepository.findOneBy({ id });
+	findById(wordId: string) {
+		return this.wordRepository.findOneBy({ id: wordId });
+	}
+
+	async findByIdWithUserLike(wordId: string, userId?: string) {
+		const word = await this.wordRepository
+			.createQueryBuilder('word')
+			.leftJoin('word.likes', 'like')
+			.where('word.id = :wordId', { wordId })
+			.select([
+				'word.id',
+				'word.name',
+				'word.description',
+				'word.diacritic',
+				'word.pronunciation',
+				'word.wrongPronunciations',
+				'word.exampleSentence',
+				'COUNT(like.id) AS likeCount',
+				'SUM(CASE WHEN like.userId = :userId THEN 1 ELSE 0 END) > 0 AS isLike',
+			])
+			.setParameter('userId', userId)
+			.groupBy('word.id')
+			.getRawOne();
+
+		const responseWordDetailDto = plainToInstance(
+			ResponseWordDetailDto,
+			word,
+			{ excludeExtraneousValues: true },
+		);
+		return responseWordDetailDto;
 	}
 
 	async findBySearchWord(requestWordSearchDto: RequestWordSearchDto) {

--- a/src/word/dto/word-detail.dto.ts
+++ b/src/word/dto/word-detail.dto.ts
@@ -43,7 +43,6 @@ export class ResponseWordDetailDto {
 	@Expose({ name: 'pronunciation' })
 	pronunciation: string[];
 
-	
 	@IsArray()
 	@Transform(({ obj }) => obj.word_wrongPronunciations)
 	@Expose({ name: 'wrongPronunciation' })

--- a/src/word/dto/word-detail.dto.ts
+++ b/src/word/dto/word-detail.dto.ts
@@ -1,0 +1,66 @@
+import { Expose, Transform } from 'class-transformer';
+import {
+	IsArray,
+	IsBoolean,
+	IsNumber,
+	IsOptional,
+	IsString,
+	IsUUID,
+} from 'class-validator';
+
+export class RequestWordDetailDto {
+	@IsUUID()
+	@IsOptional()
+	userId?: string;
+
+	@IsUUID()
+	wordId: string;
+}
+
+export class ResponseWordDetailDto {
+	@IsUUID()
+	@Transform(({ obj }) => obj.word_id)
+	@Expose({ name: 'id' })
+	id: string;
+
+	@IsString()
+	@Transform(({ obj }) => obj.word_name)
+	@Expose({ name: 'name' })
+	name: string;
+
+	@IsString()
+	@Transform(({ obj }) => obj.word_description)
+	@Expose({ name: 'description' })
+	description: string;
+
+	@IsArray()
+	@Transform(({ obj }) => obj.word_diacritic)
+	@Expose({ name: 'diacritic' })
+	diacritic: string[];
+
+	@IsArray()
+	@Transform(({ obj }) => obj.word_pronunciation)
+	@Expose({ name: 'pronunciation' })
+	pronunciation: string[];
+
+	
+	@IsArray()
+	@Transform(({ obj }) => obj.word_wrongPronunciations)
+	@Expose({ name: 'wrongPronunciation' })
+	wrongPronunciation: string[];
+
+	@IsString()
+	@Transform(({ obj }) => obj.word_exampleSentence)
+	@Expose({ name: 'exampleSentence' })
+	exampleSentence: string;
+
+	@IsBoolean()
+	@Transform(({ obj }) => obj.islike)
+	@Expose({ name: 'isLike' })
+	isLike: boolean;
+
+	@IsNumber()
+	@Transform(({ obj }) => Number(obj.likecount))
+	@Expose({ name: 'likeCount' })
+	likeCount: number;
+}

--- a/src/word/word.controller.ts
+++ b/src/word/word.controller.ts
@@ -27,6 +27,7 @@ import { UserInformationInterceptor } from '#/user/interceptors/user-information
 import { User } from '#databases/entities/user.entity';
 import { Word } from '#databases/entities/word.entity';
 
+import { RequestWordDetailDto } from './dto/word-detail.dto';
 import { RequestWordListDto, ResponseWordListDto } from './dto/word-list.dto';
 import { RequestWordSearchDto } from './dto/word-search.dto';
 import {
@@ -157,8 +158,16 @@ export class WordController {
 		description: '요청 성공시',
 	})
 	@Get('/:wordId')
-	async findById(@Param('wordId') wordId: string) {
-		return await this.wordService.getWordById(wordId);
+	@UseInterceptors(UserInformationInterceptor)
+	async findById(
+		@AuthenticatedUser() user: User,
+		@Param('wordId') wordId: string,
+	) {
+		const wordDetailDto = plainToInstance(RequestWordDetailDto, {
+			userId: user.id,
+			wordId,
+		});
+		return await this.wordService.getWordById(wordDetailDto);
 	}
 
 	@ApiOperation({

--- a/src/word/word.controller.ts
+++ b/src/word/word.controller.ts
@@ -164,7 +164,7 @@ export class WordController {
 		@Param('wordId') wordId: string,
 	) {
 		const wordDetailDto = plainToInstance(RequestWordDetailDto, {
-			userId: user.id,
+			userId: user?.id,
 			wordId,
 		});
 		return await this.wordService.getWordById(wordDetailDto);

--- a/src/word/word.service.ts
+++ b/src/word/word.service.ts
@@ -8,6 +8,7 @@ import { RequestCreateUserDto } from '#/user/dto/create-user.dto';
 import { WordRepository } from '#databases/repositories/word.repository';
 
 import { RequestUpdateWordDto } from './dto/update-word.dto';
+import { RequestWordDetailDto } from './dto/word-detail.dto';
 import { RequestWordListDto } from './dto/word-list.dto';
 import { RequestWordSearchDto } from './dto/word-search.dto';
 import { RequestWordUserLikeDto } from './dto/word-user-like.dto';
@@ -117,12 +118,12 @@ export class WordService {
 		return await this.wordRepository.findUserLikeWord(wordUserLikeDto);
 	}
 
-	async getWordById(wordId: string) {
-		const word = await this.wordRepository.findById(wordId);
+	async getWordById(wordDetailDto: RequestWordDetailDto) {
+		const word = await this.wordRepository.findByIdWithUserLike(wordDetailDto);
 
 		if (!word)
 			throw new BadRequestException(
-				`${wordId} id 를 가진 Word 가 존재하지 않습니다.`,
+				`해당 ID 를 가진 Word 가 존재하지 않습니다.`,
 			);
 		return word;
 	}

--- a/src/word/word.service.ts
+++ b/src/word/word.service.ts
@@ -119,7 +119,8 @@ export class WordService {
 	}
 
 	async getWordById(wordDetailDto: RequestWordDetailDto) {
-		const word = await this.wordRepository.findByIdWithUserLike(wordDetailDto);
+		const word =
+			await this.wordRepository.findByIdWithUserLike(wordDetailDto);
 
 		if (!word)
 			throw new BadRequestException(


### PR DESCRIPTION
## Task Summary ✨
단어 상세 조회 시 좋아요 수와 좋아요 여부 정보 추가

## Description 📑
- 단어 ID 로 단순 내용을 조회하는 Method 와, 유저의 좋아요 여부를 알리는 Method 를 분리했습니다.
- 유저가 로그인 상태인 경우 해당 단어에 좋아요를 눌렀는지를 알려주는 isLike 를 추가했습니다 (비로그인 시 false)
- 현재 해당 단어에 눌린 좋아요 수를 알려주는 likeCount 를 응답에 추가했습니다.

![111](https://github.com/Devminjeong-eum/backend/assets/74497253/881b31d3-78ea-415b-b0dc-af6ae238e6dd)


## Self Checklist ✅
- [x] 코드 리뷰 요청
- [x] PR 제목 컨벤션에 맞는지 확인
- [x] PR Label 설정