### PR TITLE
[DEV-21] 퀴즈 결과 Schema 및 생성, 조회 API 개발

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "@nestjs/typeorm": "^10.0.2",
     "axios": "^1.6.8",
     "cookie-parser": "^1.4.6",
+    "dayjs": "^1.11.11",
     "googleapis": "^135.1.0",
     "nanoid": "^5.0.7",
     "nest-winston": "^1.9.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,6 +35,9 @@ importers:
       cookie-parser:
         specifier: ^1.4.6
         version: 1.4.6
+      dayjs:
+        specifier: ^1.11.11
+        version: 1.11.11
       googleapis:
         specifier: ^135.1.0
         version: 135.1.0
@@ -1325,8 +1328,8 @@ packages:
     resolution: {integrity: sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==}
     engines: {node: '>= 8'}
 
-  dayjs@1.11.10:
-    resolution: {integrity: sha512-vjAczensTgRcqDERK0SR2XMwsF/tSvnvlv6VcF2GIhg6Sx4yOIt/irsr1RDJsKiIyBzJDpCoXiWWq28MqH2cnQ==}
+  dayjs@1.11.11:
+    resolution: {integrity: sha512-okzr3f11N6WuqYtZSvm+F776mB41wRZMhKP+hc34YdW+KmtYYK9iqvHSwo2k9FEH3fhGXvOPV6yz2IcSrfRUDg==}
 
   debug@2.6.9:
     resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==}
@@ -4817,7 +4820,7 @@ snapshots:
       shebang-command: 2.0.0
       which: 2.0.2
 
-  dayjs@1.11.10: {}
+  dayjs@1.11.11: {}
 
   debug@2.6.9:
     dependencies:
@@ -6779,7 +6782,7 @@ snapshots:
       buffer: 6.0.3
       chalk: 4.1.2
       cli-highlight: 2.1.11
-      dayjs: 1.11.10
+      dayjs: 1.11.11
       debug: 4.3.4
       dotenv: 16.4.5
       glob: 10.3.12

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -16,6 +16,7 @@ import { AuthModule } from './auth/auth.module';
 import { LikeModule } from './like/like.module';
 import { UserModule } from './user/user.module';
 import { WordModule } from './word/word.module';
+import { QuizModule } from './quiz/quiz.module';
 
 @Module({
 	imports: [
@@ -31,6 +32,7 @@ import { WordModule } from './word/word.module';
 		AuthModule,
 		WordModule,
 		LikeModule,
+		QuizModule,
 	],
 	controllers: [AppController],
 	providers: [Logger],

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -14,9 +14,9 @@ import { LoggerMiddleware } from '#middlewares/logger.middleware';
 import { AppController } from './app.controller';
 import { AuthModule } from './auth/auth.module';
 import { LikeModule } from './like/like.module';
+import { QuizModule } from './quiz/quiz.module';
 import { UserModule } from './user/user.module';
 import { WordModule } from './word/word.module';
-import { QuizModule } from './quiz/quiz.module';
 
 @Module({
 	imports: [

--- a/src/databases/entities/quizResult.entity.ts
+++ b/src/databases/entities/quizResult.entity.ts
@@ -16,4 +16,7 @@ export class QuizResult {
   
 	@Column('uuid', { array: true })
 	incorrectWordIds: string[];
+
+	@Column({ type: 'timestamp' })
+	expiredAt: Date;
 }

--- a/src/databases/entities/quizResult.entity.ts
+++ b/src/databases/entities/quizResult.entity.ts
@@ -1,7 +1,6 @@
-import { Entity, JoinColumn, ManyToOne, PrimaryGeneratedColumn } from 'typeorm';
+import { Column, Entity, JoinColumn, ManyToOne, PrimaryGeneratedColumn } from 'typeorm';
 
 import { User } from '#databases/entities/user.entity';
-import { Word } from '#databases/entities/word.entity';
 
 @Entity()
 export class QuizResult {
@@ -12,11 +11,9 @@ export class QuizResult {
 	@JoinColumn({ name: 'userId' })
 	user: User;
 
-	@ManyToOne(() => Word)
-	@JoinColumn({ name: 'correctWordIds' })
-	correctWordIds: Word[];
-
-	@ManyToOne(() => Word)
-	@JoinColumn({ name: 'incorrectWordIds' })
+	@Column('uuid', { array: true })
+	correctWordIds: string[];
+  
+	@Column('uuid', { array: true })
 	incorrectWordIds: string[];
 }

--- a/src/databases/entities/quizResult.entity.ts
+++ b/src/databases/entities/quizResult.entity.ts
@@ -1,0 +1,22 @@
+import { Entity, JoinColumn, ManyToOne, PrimaryGeneratedColumn } from 'typeorm';
+
+import { User } from '#databases/entities/user.entity';
+import { Word } from '#databases/entities/word.entity';
+
+@Entity()
+export class QuizResult {
+	@PrimaryGeneratedColumn('uuid')
+	id: string;
+
+	@ManyToOne(() => User)
+	@JoinColumn({ name: 'userId' })
+	user: User;
+
+	@ManyToOne(() => Word)
+	@JoinColumn({ name: 'correctWordIds' })
+	correctWordIds: Word[];
+
+	@ManyToOne(() => Word)
+	@JoinColumn({ name: 'incorrectWordIds' })
+	incorrectWordIds: string[];
+}

--- a/src/databases/entities/quizResult.entity.ts
+++ b/src/databases/entities/quizResult.entity.ts
@@ -1,4 +1,10 @@
-import { Column, Entity, JoinColumn, ManyToOne, PrimaryGeneratedColumn } from 'typeorm';
+import {
+	Column,
+	Entity,
+	JoinColumn,
+	ManyToOne,
+	PrimaryGeneratedColumn,
+} from 'typeorm';
 
 import { User } from '#databases/entities/user.entity';
 
@@ -13,7 +19,7 @@ export class QuizResult {
 
 	@Column('uuid', { array: true })
 	correctWordIds: string[];
-  
+
 	@Column('uuid', { array: true })
 	incorrectWordIds: string[];
 

--- a/src/databases/repositories/quizResult.repository.ts
+++ b/src/databases/repositories/quizResult.repository.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 
+import * as dayjs from 'dayjs';
 import { Repository } from 'typeorm';
 
 import { RequestCreateQuizResultDto } from '#/quiz/dto/create-quiz-result.dto';
@@ -25,11 +26,16 @@ export class QuizResultRepository {
 		quizResult.user = user;
 		quizResult.correctWordIds = correctWordIds;
 		quizResult.incorrectWordIds = incorrectWordIds;
+		quizResult.expiredAt = dayjs().add(1, 'day').toDate();
 
 		return this.quizResultRepository.save(quizResult);
 	}
 
 	async findById(quizResultId: string) {
-		return await this.quizResultRepository.findOneBy({ id: quizResultId });
+		return await this.quizResultRepository
+			.createQueryBuilder('quizResult')
+			.where('quizResult.id = :quizResultId', { quizResultId })
+			.andWhere('quizResult.expiredAt < :now', { now: new Date() })
+			.getOne();
 	}
 }

--- a/src/databases/repositories/quizResult.repository.ts
+++ b/src/databases/repositories/quizResult.repository.ts
@@ -28,4 +28,8 @@ export class QuizResultRepository {
 
 		return this.quizResultRepository.save(quizResult);
 	}
+
+	async findById(quizResultId: string) {
+		return await this.quizResultRepository.findOneBy({ id: quizResultId });
+	}
 }

--- a/src/databases/repositories/quizResult.repository.ts
+++ b/src/databases/repositories/quizResult.repository.ts
@@ -35,7 +35,7 @@ export class QuizResultRepository {
 		return await this.quizResultRepository
 			.createQueryBuilder('quizResult')
 			.where('quizResult.id = :quizResultId', { quizResultId })
-			.andWhere('quizResult.expiredAt < :now', { now: new Date() })
+			.andWhere('quizResult.expiredAt > :now', { now: new Date() })
 			.getOne();
 	}
 }

--- a/src/databases/repositories/quizResult.repository.ts
+++ b/src/databases/repositories/quizResult.repository.ts
@@ -1,0 +1,14 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+
+import { Repository } from 'typeorm';
+
+import { QuizResult } from '#/databases/entities/quizResult.entity';
+
+@Injectable()
+export class QuizResultRepository {
+	constructor(
+		@InjectRepository(QuizResult)
+		private readonly quizResultRepository: Repository<QuizResult>,
+	) {}
+}

--- a/src/databases/repositories/quizResult.repository.ts
+++ b/src/databases/repositories/quizResult.repository.ts
@@ -3,7 +3,9 @@ import { InjectRepository } from '@nestjs/typeorm';
 
 import { Repository } from 'typeorm';
 
-import { QuizResult } from '#/databases/entities/quizResult.entity';
+import { RequestCreateQuizResultDto } from '#/quiz/dto/create-quiz-result.dto';
+import { QuizResult } from '#databases/entities/quizResult.entity';
+import { User } from '#databases/entities/user.entity';
 
 @Injectable()
 export class QuizResultRepository {
@@ -11,4 +13,19 @@ export class QuizResultRepository {
 		@InjectRepository(QuizResult)
 		private readonly quizResultRepository: Repository<QuizResult>,
 	) {}
+
+	async create(createQuizResultDto: RequestCreateQuizResultDto) {
+		const { userId, correctWordIds, incorrectWordIds } =
+			createQuizResultDto;
+
+		const user = new User();
+		user.id = userId;
+
+		const quizResult = new QuizResult();
+		quizResult.user = user;
+		quizResult.correctWordIds = correctWordIds;
+		quizResult.incorrectWordIds = incorrectWordIds;
+
+		return this.quizResultRepository.save(quizResult);
+	}
 }

--- a/src/databases/repositories/word.repository.ts
+++ b/src/databases/repositories/word.repository.ts
@@ -60,7 +60,7 @@ export class WordRepository {
 	}) {
 		const queryBuilder = this.wordRepository
 			.createQueryBuilder('word')
-			.leftJoinAndSelect('word.likes', 'like', 'like.id')
+			.leftJoin('word.likes', 'like')
 			.where('word.id IN (:...wordIdList)', { wordIdList })
 			.select([
 				'word.id',

--- a/src/databases/repositories/word.repository.ts
+++ b/src/databases/repositories/word.repository.ts
@@ -51,6 +51,37 @@ export class WordRepository {
 		return this.wordRepository.findOneBy({ id: wordId });
 	}
 
+	async findByIdListWithUserLike({
+		wordIdList,
+		userId,
+	}: {
+		wordIdList: string[];
+		userId?: string;
+	}) {
+		const queryBuilder = this.wordRepository
+			.createQueryBuilder('word')
+			.leftJoinAndSelect('word.likes', 'like', 'like.id')
+			.where('word.id IN (:...wordIdList)', { wordIdList })
+			.select([
+				'word.id',
+				'word.name',
+				'word.diacritic',
+				'word.pronunciation',
+			]);
+
+		if (userId) {
+			queryBuilder
+				.addSelect([
+					'SUM(CASE WHEN like.userId = :userId THEN 1 ELSE 0 END) > 0 AS isLike',
+				])
+				.setParameters({ userId });
+		} else {
+			queryBuilder.addSelect(['false AS isLike']);
+		}
+
+		return await queryBuilder.groupBy('word.id').getRawMany();
+	}
+
 	async findByIdWithUserLike(wordDetailDto: RequestWordDetailDto) {
 		const { wordId, userId } = wordDetailDto;
 
@@ -74,7 +105,7 @@ export class WordRepository {
 				.addSelect([
 					'SUM(CASE WHEN like.userId = :userId THEN 1 ELSE 0 END) > 0 AS isLike',
 				])
-				.setParameter('userId', userId);
+				.setParameters({ userId });
 		} else {
 			queryBuilder.addSelect(['false AS isLike']);
 		}

--- a/src/quiz/dto/create-quiz-result.dto.ts
+++ b/src/quiz/dto/create-quiz-result.dto.ts
@@ -1,0 +1,20 @@
+import {
+	IsArray,
+	IsUUID,
+    MaxLength,
+} from 'class-validator';
+
+export class RequestCreateQuizResultDto {
+	@IsUUID()
+	userId: string;
+
+    @IsArray()
+    @IsUUID()
+    @MaxLength(10)
+    correctWordIds: string[];
+
+    @IsArray()
+    @IsUUID()
+    @MaxLength(10)
+    incorrectWordIds: string[]; 
+}

--- a/src/quiz/dto/create-quiz-result.dto.ts
+++ b/src/quiz/dto/create-quiz-result.dto.ts
@@ -1,3 +1,4 @@
+import { Expose, Transform } from 'class-transformer';
 import {
 	IsArray,
 	IsUUID,
@@ -16,5 +17,24 @@ export class RequestCreateQuizResultDto {
     @IsArray()
     @IsUUID()
     @MaxLength(10)
+    incorrectWordIds: string[]; 
+}
+
+export class ResponseCreateQuizResultDto {
+    @IsUUID()
+    @Transform(({ obj }) => obj.id)
+    @Expose()
+	userId: string;
+    
+    @IsArray()
+    @IsUUID()
+    @MaxLength(10)
+    @Expose()
+    correctWordIds: string[];
+
+    @IsArray()
+    @IsUUID()
+    @MaxLength(10)
+    @Expose()
     incorrectWordIds: string[]; 
 }

--- a/src/quiz/dto/create-quiz-result.dto.ts
+++ b/src/quiz/dto/create-quiz-result.dto.ts
@@ -1,40 +1,36 @@
 import { Expose, Transform } from 'class-transformer';
-import {
-	IsArray,
-	IsUUID,
-    MaxLength,
-} from 'class-validator';
+import { IsArray, IsUUID, MaxLength } from 'class-validator';
 
 export class RequestCreateQuizResultDto {
 	@IsUUID()
 	userId: string;
 
-    @IsArray()
-    @IsUUID()
-    @MaxLength(10)
-    correctWordIds: string[];
+	@IsArray()
+	@IsUUID()
+	@MaxLength(10)
+	correctWordIds: string[];
 
-    @IsArray()
-    @IsUUID()
-    @MaxLength(10)
-    incorrectWordIds: string[]; 
+	@IsArray()
+	@IsUUID()
+	@MaxLength(10)
+	incorrectWordIds: string[];
 }
 
 export class ResponseCreateQuizResultDto {
-    @IsUUID()
-    @Transform(({ obj }) => obj.id)
-    @Expose()
+	@IsUUID()
+	@Transform(({ obj }) => obj.id)
+	@Expose()
 	userId: string;
-    
-    @IsArray()
-    @IsUUID()
-    @MaxLength(10)
-    @Expose()
-    correctWordIds: string[];
 
-    @IsArray()
-    @IsUUID()
-    @MaxLength(10)
-    @Expose()
-    incorrectWordIds: string[]; 
+	@IsArray()
+	@IsUUID()
+	@MaxLength(10)
+	@Expose()
+	correctWordIds: string[];
+
+	@IsArray()
+	@IsUUID()
+	@MaxLength(10)
+	@Expose()
+	incorrectWordIds: string[];
 }

--- a/src/quiz/dto/quiz-result.dto.ts
+++ b/src/quiz/dto/quiz-result.dto.ts
@@ -1,0 +1,49 @@
+import { Expose, Transform, Type } from 'class-transformer';
+import { IsBoolean, IsOptional, IsString, IsUUID } from 'class-validator';
+
+export class RequestQuizResultDto {
+	@IsOptional()
+	@IsUUID()
+	userId?: string;
+
+	@IsUUID()
+	quizResultId: string;
+}
+
+class QuizResultWord {
+    @IsUUID()
+    @Transform(({ obj}) => obj.word_id)
+    @Expose({ name: 'wordId' })
+    wordId: string;
+
+	@IsString()
+	@Transform(({ obj }) => obj.word_name)
+	@Expose({ name: 'name' })
+	name: string;
+
+    @IsString()
+	@Transform(({ obj }) => obj.word_pronunciation[0])
+	@Expose({ name: 'pronunciation' })
+	pronunciation: string;
+
+    @IsString()
+	@Transform(({ obj }) => obj.word_diacritic[0])
+	@Expose({ name: 'diacritic' })
+	diacritic: string;
+
+    @IsBoolean()
+	@Transform(({ obj }) => obj.islike)
+	@Expose({ name: 'isLike' })
+	isLike: boolean;
+}
+
+export class ResponseQuizResultDto {
+    @IsUUID()
+    quizResultId: string;
+
+    @Type(() => QuizResultWord)
+    correctWords: QuizResultWord[];
+
+    @Type(() => QuizResultWord)
+    incorrectWords: QuizResultWord[];
+}

--- a/src/quiz/dto/quiz-result.dto.ts
+++ b/src/quiz/dto/quiz-result.dto.ts
@@ -1,5 +1,5 @@
 import { Expose, Transform, Type } from 'class-transformer';
-import { IsBoolean, IsOptional, IsString, IsUUID } from 'class-validator';
+import { IsBoolean, IsNumber, IsOptional, IsString, IsUUID } from 'class-validator';
 
 export class RequestQuizResultDto {
 	@IsOptional()
@@ -40,6 +40,9 @@ class QuizResultWord {
 export class ResponseQuizResultDto {
     @IsUUID()
     quizResultId: string;
+
+	@IsNumber()
+	score: number;
 
     @Type(() => QuizResultWord)
     @Expose({ name: 'correctWords' })

--- a/src/quiz/dto/quiz-result.dto.ts
+++ b/src/quiz/dto/quiz-result.dto.ts
@@ -39,9 +39,11 @@ class QuizResultWord {
 
 export class ResponseQuizResultDto {
     @IsUUID()
+	@Expose()
     quizResultId: string;
 
 	@IsNumber()
+	@Expose()
 	score: number;
 
     @Type(() => QuizResultWord)

--- a/src/quiz/dto/quiz-result.dto.ts
+++ b/src/quiz/dto/quiz-result.dto.ts
@@ -1,5 +1,11 @@
 import { Expose, Transform, Type } from 'class-transformer';
-import { IsBoolean, IsNumber, IsOptional, IsString, IsUUID } from 'class-validator';
+import {
+	IsBoolean,
+	IsNumber,
+	IsOptional,
+	IsString,
+	IsUUID,
+} from 'class-validator';
 
 export class RequestQuizResultDto {
 	@IsOptional()
@@ -11,46 +17,46 @@ export class RequestQuizResultDto {
 }
 
 class QuizResultWord {
-    @IsUUID()
-    @Transform(({ obj}) => obj.word_id)
-    @Expose({ name: 'wordId' })
-    wordId: string;
+	@IsUUID()
+	@Transform(({ obj }) => obj.word_id)
+	@Expose({ name: 'wordId' })
+	wordId: string;
 
 	@IsString()
 	@Transform(({ obj }) => obj.word_name)
 	@Expose({ name: 'name' })
 	name: string;
 
-    @IsString()
+	@IsString()
 	@Transform(({ obj }) => obj.word_pronunciation[0])
 	@Expose({ name: 'pronunciation' })
 	pronunciation: string;
 
-    @IsString()
+	@IsString()
 	@Transform(({ obj }) => obj.word_diacritic[0])
 	@Expose({ name: 'diacritic' })
 	diacritic: string;
 
-    @IsBoolean()
+	@IsBoolean()
 	@Transform(({ obj }) => obj.islike)
 	@Expose({ name: 'isLike' })
 	isLike: boolean;
 }
 
 export class ResponseQuizResultDto {
-    @IsUUID()
+	@IsUUID()
 	@Expose()
-    quizResultId: string;
+	quizResultId: string;
 
 	@IsNumber()
 	@Expose()
 	score: number;
 
-    @Type(() => QuizResultWord)
-    @Expose({ name: 'correctWords' })
+	@Type(() => QuizResultWord)
+	@Expose({ name: 'correctWords' })
 	correctWords: QuizResultWord[];
 
-    @Type(() => QuizResultWord)
+	@Type(() => QuizResultWord)
 	@Expose({ name: 'incorrectWords' })
-    incorrectWords: QuizResultWord[];
+	incorrectWords: QuizResultWord[];
 }

--- a/src/quiz/dto/quiz-result.dto.ts
+++ b/src/quiz/dto/quiz-result.dto.ts
@@ -42,8 +42,10 @@ export class ResponseQuizResultDto {
     quizResultId: string;
 
     @Type(() => QuizResultWord)
-    correctWords: QuizResultWord[];
+    @Expose({ name: 'correctWords' })
+	correctWords: QuizResultWord[];
 
     @Type(() => QuizResultWord)
+	@Expose({ name: 'incorrectWords' })
     incorrectWords: QuizResultWord[];
 }

--- a/src/quiz/quiz.controller.ts
+++ b/src/quiz/quiz.controller.ts
@@ -1,0 +1,7 @@
+import { Controller } from '@nestjs/common';
+import { QuizService } from './quiz.service';
+
+@Controller('quiz')
+export class QuizController {
+  constructor(private readonly quizService: QuizService) {}
+}

--- a/src/quiz/quiz.controller.ts
+++ b/src/quiz/quiz.controller.ts
@@ -38,7 +38,7 @@ export class QuizController {
 	}
 
 	@UseInterceptors(UserInformationInterceptor)
-	@Get('/:quizResultId')
+	@Get('/result/:quizResultId')
 	async findQuizResultById(
 		@AuthenticatedUser() user: User,
 		@Param('quizResultId') quizResultId: string,

--- a/src/quiz/quiz.controller.ts
+++ b/src/quiz/quiz.controller.ts
@@ -1,12 +1,22 @@
-import { Body, Controller, Post, UseGuards } from '@nestjs/common';
+import {
+	Body,
+	Controller,
+	Get,
+	Param,
+	Post,
+	UseGuards,
+	UseInterceptors,
+} from '@nestjs/common';
 
 import { plainToInstance } from 'class-transformer';
 
 import { AuthenticatedUser } from '#/auth/decorator/auth.decorator';
 import { AuthenticationGuard } from '#/auth/guard/auth.guard';
+import { UserInformationInterceptor } from '#/user/interceptors/user-information.interceptor';
 import { User } from '#databases/entities/user.entity';
 
 import { RequestCreateQuizResultDto } from './dto/create-quiz-result.dto';
+import { RequestQuizResultDto } from './dto/quiz-result.dto';
 import { QuizService } from './quiz.service';
 
 @Controller('quiz')
@@ -25,5 +35,19 @@ export class QuizController {
 			{ userId: user.id, correctWordIds, incorrectWordIds },
 		);
 		return this.quizService.createQuizResult(createQuizResultDto);
+	}
+
+	@UseInterceptors(UserInformationInterceptor)
+	@Get('/:quizResultId')
+	async findQuizResultById(
+		@AuthenticatedUser() user: User,
+		@Param('quizResultId') quizResultId: string,
+	) {
+		const quizResultDto = plainToInstance(RequestQuizResultDto, {
+			userId: user?.id,
+			quizResultId,
+		});
+
+    return this.quizService.findQuizResultById(quizResultDto)
 	}
 }

--- a/src/quiz/quiz.controller.ts
+++ b/src/quiz/quiz.controller.ts
@@ -1,7 +1,29 @@
-import { Controller } from '@nestjs/common';
+import { Body, Controller, Post, UseGuards } from '@nestjs/common';
+
+import { plainToInstance } from 'class-transformer';
+
+import { AuthenticatedUser } from '#/auth/decorator/auth.decorator';
+import { AuthenticationGuard } from '#/auth/guard/auth.guard';
+import { User } from '#databases/entities/user.entity';
+
+import { RequestCreateQuizResultDto } from './dto/create-quiz-result.dto';
 import { QuizService } from './quiz.service';
 
 @Controller('quiz')
 export class QuizController {
-  constructor(private readonly quizService: QuizService) {}
+	constructor(private readonly quizService: QuizService) {}
+
+	@UseGuards(AuthenticationGuard)
+	@Post('/result')
+	async createQuizResult(
+		@AuthenticatedUser() user: User,
+		@Body('correctWordIds') correctWordIds: string[],
+		@Body('incorrectWordIds') incorrectWordIds: string[],
+	) {
+		const createQuizResultDto = plainToInstance(
+			RequestCreateQuizResultDto,
+			{ userId: user.id, correctWordIds, incorrectWordIds },
+		);
+		return this.quizService.createQuizResult(createQuizResultDto);
+	}
 }

--- a/src/quiz/quiz.controller.ts
+++ b/src/quiz/quiz.controller.ts
@@ -48,6 +48,6 @@ export class QuizController {
 			quizResultId,
 		});
 
-    return this.quizService.findQuizResultById(quizResultDto)
+		return this.quizService.findQuizResultById(quizResultDto);
 	}
 }

--- a/src/quiz/quiz.module.ts
+++ b/src/quiz/quiz.module.ts
@@ -1,22 +1,28 @@
 import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
 
 import { AuthModule } from '#/auth/auth.module';
 import { UserModule } from '#/user/user.module';
+import { WordModule } from '#/word/word.module';
+import { QuizResult } from '#databases/entities/quizResult.entity';
 import { QuizResultRepository } from '#databases/repositories/quizResult.repository';
-import { WordRepository } from '#databases/repositories/word.repository';
 
 import { QuizController } from './quiz.controller';
 import { QuizService } from './quiz.service';
 
 @Module({
-	imports: [AuthModule, UserModule],
+	imports: [
+		TypeOrmModule.forFeature([QuizResult]),
+		AuthModule,
+		UserModule,
+		WordModule,
+	],
 	controllers: [QuizController],
 	providers: [
 		// Service
 		QuizService,
 		// Repository
 		QuizResultRepository,
-		WordRepository,
 	],
 })
 export class QuizModule {}

--- a/src/quiz/quiz.module.ts
+++ b/src/quiz/quiz.module.ts
@@ -1,6 +1,7 @@
 import { Module } from '@nestjs/common';
 
 import { AuthModule } from '#/auth/auth.module';
+import { UserModule } from '#/user/user.module';
 import { QuizResultRepository } from '#databases/repositories/quizResult.repository';
 import { WordRepository } from '#databases/repositories/word.repository';
 
@@ -8,7 +9,7 @@ import { QuizController } from './quiz.controller';
 import { QuizService } from './quiz.service';
 
 @Module({
-	imports: [AuthModule],
+	imports: [AuthModule, UserModule],
 	controllers: [QuizController],
 	providers: [
 		// Service

--- a/src/quiz/quiz.module.ts
+++ b/src/quiz/quiz.module.ts
@@ -1,0 +1,17 @@
+import { Module } from '@nestjs/common';
+
+import { QuizResultRepository } from '#databases/repositories/quizResult.repository';
+
+import { QuizController } from './quiz.controller';
+import { QuizService } from './quiz.service';
+
+@Module({
+	controllers: [QuizController],
+	providers: [
+		// Service
+		QuizService,
+		// Repository
+		QuizResultRepository,
+	],
+})
+export class QuizModule {}

--- a/src/quiz/quiz.module.ts
+++ b/src/quiz/quiz.module.ts
@@ -1,17 +1,21 @@
 import { Module } from '@nestjs/common';
 
+import { AuthModule } from '#/auth/auth.module';
 import { QuizResultRepository } from '#databases/repositories/quizResult.repository';
+import { WordRepository } from '#databases/repositories/word.repository';
 
 import { QuizController } from './quiz.controller';
 import { QuizService } from './quiz.service';
 
 @Module({
+	imports: [AuthModule],
 	controllers: [QuizController],
 	providers: [
 		// Service
 		QuizService,
 		// Repository
 		QuizResultRepository,
+		WordRepository,
 	],
 })
 export class QuizModule {}

--- a/src/quiz/quiz.service.ts
+++ b/src/quiz/quiz.service.ts
@@ -1,0 +1,4 @@
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class QuizService {}

--- a/src/quiz/quiz.service.ts
+++ b/src/quiz/quiz.service.ts
@@ -1,4 +1,27 @@
-import { Injectable } from '@nestjs/common';
+import { BadRequestException, Injectable } from '@nestjs/common';
+
+import { QuizResultRepository } from '#databases/repositories/quizResult.repository';
+
+import { RequestCreateQuizResultDto } from './dto/create-quiz-result.dto';
 
 @Injectable()
-export class QuizService {}
+export class QuizService {
+	constructor(private readonly quizResultRepository: QuizResultRepository) {}
+
+	private MAX_QUIZ_AMOUNT = 10;
+
+	async createQuizResult(createQuizResultDto: RequestCreateQuizResultDto) {
+		const { correctWordIds, incorrectWordIds } = createQuizResultDto;
+		const isValidQuizAmount =
+			new Set([...correctWordIds, ...incorrectWordIds]).size !==
+			this.MAX_QUIZ_AMOUNT;
+
+		if (isValidQuizAmount) {
+			throw new BadRequestException(
+				'퀴즈에 포함된 문제의 수량은 10개여야 합니다.',
+			);
+		}
+
+		return await this.quizResultRepository.create(createQuizResultDto);
+	}
+}

--- a/src/quiz/quiz.service.ts
+++ b/src/quiz/quiz.service.ts
@@ -1,12 +1,22 @@
 import { BadRequestException, Injectable } from '@nestjs/common';
 
+import { plainToInstance } from 'class-transformer';
+
 import { QuizResultRepository } from '#databases/repositories/quizResult.repository';
+import { WordRepository } from '#databases/repositories/word.repository';
 
 import { RequestCreateQuizResultDto } from './dto/create-quiz-result.dto';
+import {
+	RequestQuizResultDto,
+	ResponseQuizResultDto,
+} from './dto/quiz-result.dto';
 
 @Injectable()
 export class QuizService {
-	constructor(private readonly quizResultRepository: QuizResultRepository) {}
+	constructor(
+		private readonly quizResultRepository: QuizResultRepository,
+		private readonly wordRepository: WordRepository,
+	) {}
 
 	private MAX_QUIZ_AMOUNT = 10;
 
@@ -23,5 +33,37 @@ export class QuizService {
 		}
 
 		return await this.quizResultRepository.create(createQuizResultDto);
+	}
+
+	async findQuizResultById(quizResultDto: RequestQuizResultDto) {
+		const { userId, quizResultId } = quizResultDto;
+		const quizResult =
+			await this.quizResultRepository.findById(quizResultId);
+
+		if (!quizResult) {
+			throw new BadRequestException(
+				'해당 ID 를 가진 퀴즈 결과 데이터가 없습니다.',
+			);
+		}
+
+		const { id, correctWordIds, incorrectWordIds } = quizResult;
+		const [correctWords, incorrectWords] = await Promise.all([
+			this.wordRepository.findByIdListWithUserLike({
+				wordIdList: correctWordIds,
+				userId,
+			}),
+			this.wordRepository.findByIdListWithUserLike({
+				wordIdList: incorrectWordIds,
+				userId,
+			}),
+		]);
+
+		const responseQuizResultDto = plainToInstance(ResponseQuizResultDto, {
+			id,
+			correctWords,
+			incorrectWords,
+		});
+
+		return responseQuizResultDto;
 	}
 }

--- a/src/quiz/quiz.service.ts
+++ b/src/quiz/quiz.service.ts
@@ -70,10 +70,13 @@ export class QuizService {
 			}),
 		]);
 
+		const score = correctWordIds.length * 10;
+
 		const responseQuizResultDto = plainToInstance(
 			ResponseQuizResultDto,
 			{
 				quizResultId: id,
+				score,
 				correctWords,
 				incorrectWords,
 			},

--- a/src/quiz/quiz.service.ts
+++ b/src/quiz/quiz.service.ts
@@ -5,7 +5,10 @@ import { plainToInstance } from 'class-transformer';
 import { QuizResultRepository } from '#databases/repositories/quizResult.repository';
 import { WordRepository } from '#databases/repositories/word.repository';
 
-import { RequestCreateQuizResultDto } from './dto/create-quiz-result.dto';
+import {
+	RequestCreateQuizResultDto,
+	ResponseCreateQuizResultDto,
+} from './dto/create-quiz-result.dto';
 import {
 	RequestQuizResultDto,
 	ResponseQuizResultDto,
@@ -32,7 +35,16 @@ export class QuizService {
 			);
 		}
 
-		return await this.quizResultRepository.create(createQuizResultDto);
+		const createdQuizResult =
+			await this.quizResultRepository.create(createQuizResultDto);
+
+		const responseCreateQuizResultDto = plainToInstance(
+			ResponseCreateQuizResultDto,
+			createdQuizResult,
+			{ excludeExtraneousValues: true },
+		);
+
+		return responseCreateQuizResultDto;
 	}
 
 	async findQuizResultById(quizResultDto: RequestQuizResultDto) {
@@ -58,11 +70,17 @@ export class QuizService {
 			}),
 		]);
 
-		const responseQuizResultDto = plainToInstance(ResponseQuizResultDto, {
-			id,
-			correctWords,
-			incorrectWords,
-		});
+		const responseQuizResultDto = plainToInstance(
+			ResponseQuizResultDto,
+			{
+				quizResultId: id,
+				correctWords,
+				incorrectWords,
+			},
+			{
+				excludeExtraneousValues: true,
+			},
+		);
 
 		return responseQuizResultDto;
 	}

--- a/src/word/word.module.ts
+++ b/src/word/word.module.ts
@@ -24,5 +24,6 @@ import { WordService } from './word.service';
 		// Repository
 		WordRepository,
 	],
+	exports: [WordService, WordRepository],
 })
 export class WordModule {}


### PR DESCRIPTION
## Task Summary ✨
- 퀴즈 결과 Schema 및 생성, 조회 API 개발

## Description 📑
- 퀴즈 결과를 저장하는 QuizResult Repository 및 Schema 를 추가했습니다.
- 맞춘 단어 ID, 틀린 단어 ID 를 넘겨 퀴즈 결과를 생성하는 API 를 추가했습니다.
- 퀴즈 결과 ID 를 기반으로 퀴즈 풀이 결과를 조회하는 API 를 추가했습니다. (좋아요 여부, 점수 포함)
- 퀴즈 결과 생성 일자를 기준으로 1일 후 만료되도록 조건 생성 및 적용

## Self Checklist ✅
- [x] 코드 리뷰 요청
- [x] PR 제목 컨벤션에 맞는지 확인
- [x] PR Label 설정