### PR TITLE
[DEV-46] 퀴즈 선택지 Schema 및 SpreadSheet 연동 기능 개발

### DIFF
--- a/src/databases/entities/quizSelection.entity.ts
+++ b/src/databases/entities/quizSelection.entity.ts
@@ -1,4 +1,10 @@
-import { Column, Entity, JoinColumn, OneToOne, PrimaryGeneratedColumn } from 'typeorm';
+import {
+	Column,
+	Entity,
+	JoinColumn,
+	OneToOne,
+	PrimaryGeneratedColumn,
+} from 'typeorm';
 
 import { Word } from './word.entity';
 

--- a/src/databases/entities/quizSelection.entity.ts
+++ b/src/databases/entities/quizSelection.entity.ts
@@ -1,0 +1,18 @@
+import { Column, Entity, OneToOne, PrimaryGeneratedColumn } from 'typeorm';
+
+import { Word } from './word.entity';
+
+@Entity()
+export class QuizSelection {
+	@PrimaryGeneratedColumn('uuid')
+	id: string;
+
+	@OneToOne(() => Word, { eager: true })
+	word: Word;
+
+	@Column()
+	correct: string;
+
+	@Column({ array: true })
+	incorrectList: string[];
+}

--- a/src/databases/entities/quizSelection.entity.ts
+++ b/src/databases/entities/quizSelection.entity.ts
@@ -10,9 +10,9 @@ export class QuizSelection {
 	@OneToOne(() => Word, { eager: true })
 	word: Word;
 
-	@Column()
+	@Column({ type: 'varchar' })
 	correct: string;
 
-	@Column({ array: true })
+	@Column({ type: 'varchar', array: true })
 	incorrectList: string[];
 }

--- a/src/databases/entities/quizSelection.entity.ts
+++ b/src/databases/entities/quizSelection.entity.ts
@@ -1,4 +1,4 @@
-import { Column, Entity, OneToOne, PrimaryGeneratedColumn } from 'typeorm';
+import { Column, Entity, JoinColumn, OneToOne, PrimaryGeneratedColumn } from 'typeorm';
 
 import { Word } from './word.entity';
 
@@ -8,6 +8,7 @@ export class QuizSelection {
 	id: string;
 
 	@OneToOne(() => Word, { eager: true })
+	@JoinColumn()
 	word: Word;
 
 	@Column({ type: 'varchar' })

--- a/src/databases/repositories/quizSelection.repository.ts
+++ b/src/databases/repositories/quizSelection.repository.ts
@@ -16,8 +16,10 @@ export class QuizSelectionRepository {
 	) {}
 
 	async create(word: Word, createQuizSelectDto: RequestCreateQuizSelectDto) {
-		const quizSelection =
-			this.quizSelectionRepository.create({ word, ...createQuizSelectDto});
+		const quizSelection = this.quizSelectionRepository.create({
+			word,
+			...createQuizSelectDto,
+		});
 		return this.quizSelectionRepository.save(quizSelection);
 	}
 
@@ -60,16 +62,9 @@ export class QuizSelectionRepository {
 	findRandomQuizSelection() {
 		return this.quizSelectionRepository
 			.createQueryBuilder('quizSelection')
-			.select([
-				'quizSelection.correct',
-				'quizSelection.incorrectList',
-			])
+			.select(['quizSelection.correct', 'quizSelection.incorrectList'])
 			.leftJoin('quizSelection.word', 'word')
-			.addSelect([
-				'word.id',
-				'word.name',
-				'word.diacritic',
-			])
+			.addSelect(['word.id', 'word.name', 'word.diacritic'])
 			.orderBy('RANDOM()')
 			.limit(10)
 			.getRawMany();

--- a/src/databases/repositories/quizSelection.repository.ts
+++ b/src/databases/repositories/quizSelection.repository.ts
@@ -19,4 +19,25 @@ export class QuizSelectionRepository {
 
 		return this.quizSelectionRepository.save(quizSelection);
 	}
+
+	findById(quizSelectionId: string) {
+		return this.quizSelectionRepository
+			.createQueryBuilder('quizSelection')
+			.where('quizSelection.id = :quizSelectionId', { quizSelectionId })
+			.getOne();
+	}
+
+	findByWordId(wordId: string) {
+		return this.quizSelectionRepository
+			.createQueryBuilder('quizSelection')
+			.leftJoinAndSelect('quizSelection.word', 'word')
+			.where('word.id = :wordId', { wordId })
+			.select([
+				'quizSelection.id',
+				'quizSelection.correct',
+				'quizSelection.incorrectList',
+				'word.id',
+			])
+			.getOne();
+	}
 }

--- a/src/databases/repositories/quizSelection.repository.ts
+++ b/src/databases/repositories/quizSelection.repository.ts
@@ -4,6 +4,7 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 
 import { RequestCreateQuizSelectDto } from '#/quiz/dto/create-quiz-selection.dto';
+import { RequestUpdateQuizSelectDto } from '#/quiz/dto/update-quiz-selection.dto';
 import { QuizSelection } from '#databases/entities/quizSelection.entity';
 
 @Injectable()
@@ -18,6 +19,17 @@ export class QuizSelectionRepository {
 			this.quizSelectionRepository.create(createQuizSelectDto);
 
 		return this.quizSelectionRepository.save(quizSelection);
+	}
+
+	async update(
+		quizSelectionId: string,
+		updateFieldDto: RequestUpdateQuizSelectDto,
+	): Promise<QuizSelection> {
+		const updateResult = await this.quizSelectionRepository.update(
+			quizSelectionId,
+			updateFieldDto,
+		);
+		return updateResult.raw;
 	}
 
 	findById(quizSelectionId: string) {

--- a/src/databases/repositories/quizSelection.repository.ts
+++ b/src/databases/repositories/quizSelection.repository.ts
@@ -1,0 +1,22 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+
+import { Repository } from 'typeorm';
+
+import { RequestCreateQuizSelectDto } from '#/quiz/dto/create-quiz-selection.dto';
+import { QuizSelection } from '#databases/entities/quizSelection.entity';
+
+@Injectable()
+export class QuizSelectionRepository {
+	constructor(
+		@InjectRepository(QuizSelection)
+		private readonly quizSelectionRepository: Repository<QuizSelection>,
+	) {}
+
+	async create(createQuizSelectDto: RequestCreateQuizSelectDto) {
+		const quizSelection =
+			this.quizSelectionRepository.create(createQuizSelectDto);
+
+		return this.quizSelectionRepository.save(quizSelection);
+	}
+}

--- a/src/databases/repositories/word.repository.ts
+++ b/src/databases/repositories/word.repository.ts
@@ -38,9 +38,12 @@ export class WordRepository {
 		return await this.wordRepository.save(registeredUser);
 	}
 
-	async update(id: string, updateFieldDto: RequestUpdateWordDto) {
+	async update(
+		id: string,
+		updateFieldDto: RequestUpdateWordDto,
+	): Promise<Word> {
 		const result = await this.wordRepository.update({ id }, updateFieldDto);
-		return result.raw as Word;
+		return result.raw;
 	}
 
 	findByName(name: string) {

--- a/src/databases/repositories/word.repository.ts
+++ b/src/databases/repositories/word.repository.ts
@@ -5,8 +5,7 @@ import { plainToInstance } from 'class-transformer';
 import { DataSource, Repository } from 'typeorm';
 
 import { PaginationDto, PaginationMetaDto } from '#/common/dto/pagination.dto';
-import { Word } from '#/databases/entities/word.entity';
-import { RequestCreateUserDto } from '#/user/dto/create-user.dto';
+import { RequestCreateWordDto } from '#/word/dto/create-word.dto';
 import { RequestUpdateWordDto } from '#/word/dto/update-word.dto';
 import {
 	RequestWordDetailDto,
@@ -24,6 +23,7 @@ import {
 	RequestWordUserLikeDto,
 	ResponseWordUserLikeDto,
 } from '#/word/dto/word-user-like.dto';
+import { Word } from '#databases/entities/word.entity';
 
 @Injectable()
 export class WordRepository {
@@ -33,7 +33,7 @@ export class WordRepository {
 		private readonly dataSource: DataSource,
 	) {}
 
-	async create(createWordDto: RequestCreateUserDto) {
+	async create(createWordDto: RequestCreateWordDto) {
 		const registeredUser = this.wordRepository.create(createWordDto);
 		return await this.wordRepository.save(registeredUser);
 	}

--- a/src/databases/repositories/word.repository.ts
+++ b/src/databases/repositories/word.repository.ts
@@ -197,8 +197,6 @@ export class WordRepository {
 			queryBuilder.getCount(),
 		]);
 
-		console.log(words.length);
-
 		const responseWordListDto = plainToInstance(
 			ResponseWordListDto,
 			words,

--- a/src/quiz/dto/create-quiz-selection.dto.ts
+++ b/src/quiz/dto/create-quiz-selection.dto.ts
@@ -1,9 +1,6 @@
-import { IsArray, IsString, IsUUID, Length } from 'class-validator';
+import { IsArray, IsString, Length } from 'class-validator';
 
 export class RequestCreateQuizSelectDto {
-	@IsUUID()
-	wordId: string;
-
 	@IsString()
 	correct: string;
 

--- a/src/quiz/dto/create-quiz-selection.dto.ts
+++ b/src/quiz/dto/create-quiz-selection.dto.ts
@@ -1,0 +1,13 @@
+import { IsArray, IsString, IsUUID, Length } from 'class-validator';
+
+export class RequestCreateQuizSelectDto {
+	@IsUUID()
+	wordId: string;
+
+	@IsString()
+	correct: string;
+
+	@IsArray()
+	@Length(3)
+	incorrectList: string[];
+}

--- a/src/quiz/dto/quiz-selection.dto.ts
+++ b/src/quiz/dto/quiz-selection.dto.ts
@@ -1,0 +1,32 @@
+import { Expose, Transform } from 'class-transformer';
+import { IsArray, IsString } from 'class-validator';
+
+export class ResponseQuizSelectionDto {
+	@IsString()
+	@Transform(({ obj }) => obj.quizSelection_correct)
+	@Expose()
+	correct: string;
+
+	@IsArray()
+	@Transform(({ obj }) => [
+		...obj.quizSelection_incorrectList,
+		obj.quizSelection_correct,
+	])
+	@Expose({ name: 'selections' })
+	selections: string[];
+
+	@IsString()
+	@Transform(({ obj }) => obj.word_id)
+	@Expose()
+	wordId: string;
+
+	@IsString()
+	@Transform(({ obj }) => obj.word_name)
+	@Expose()
+	name: string;
+
+	@IsString()
+	@Transform(({ obj }) => obj.word_diacritic[0])
+	@Expose()
+	diacritic: string;
+}

--- a/src/quiz/dto/update-quiz-selection.dto.ts
+++ b/src/quiz/dto/update-quiz-selection.dto.ts
@@ -1,9 +1,6 @@
-import { IsArray, IsString, IsUUID, Length } from 'class-validator';
+import { IsArray, IsString, Length } from 'class-validator';
 
 export class RequestUpdateQuizSelectDto {
-	@IsUUID()
-	wordId: string;
-
 	@IsString()
 	correct: string;
 

--- a/src/quiz/dto/update-quiz-selection.dto.ts
+++ b/src/quiz/dto/update-quiz-selection.dto.ts
@@ -1,0 +1,13 @@
+import { IsArray, IsString, IsUUID, Length } from 'class-validator';
+
+export class RequestUpdateQuizSelectDto {
+	@IsUUID()
+	wordId: string;
+
+	@IsString()
+	correct: string;
+
+	@IsArray()
+	@Length(3)
+	incorrectList: string[];
+}

--- a/src/quiz/quiz.controller.ts
+++ b/src/quiz/quiz.controller.ts
@@ -52,6 +52,12 @@ export class QuizController {
 		return this.quizService.findQuizResultById(quizResultDto);
 	}
 
+
+	@Get('/selection')
+	findQuizSelectionRandom() {
+		return this.quizService.findQuizSelectionRandom();
+	}
+
 	@UseGuards(AuthenticationGuard)
 	@Patch('/selection/spread-sheet')
 	patchUpdateSpreadSheet() {

--- a/src/quiz/quiz.controller.ts
+++ b/src/quiz/quiz.controller.ts
@@ -3,6 +3,7 @@ import {
 	Controller,
 	Get,
 	Param,
+	Patch,
 	Post,
 	UseGuards,
 	UseInterceptors,
@@ -49,5 +50,11 @@ export class QuizController {
 		});
 
 		return this.quizService.findQuizResultById(quizResultDto);
+	}
+
+	@UseGuards(AuthenticationGuard)
+	@Patch('/selection/spread-sheet')
+	patchUpdateSpreadSheet() {
+		return this.quizService.updateQuizSelectionList();
 	}
 }

--- a/src/quiz/quiz.controller.ts
+++ b/src/quiz/quiz.controller.ts
@@ -52,7 +52,6 @@ export class QuizController {
 		return this.quizService.findQuizResultById(quizResultDto);
 	}
 
-
 	@Get('/selection')
 	findQuizSelectionRandom() {
 		return this.quizService.findQuizSelectionRandom();

--- a/src/quiz/quiz.module.ts
+++ b/src/quiz/quiz.module.ts
@@ -2,19 +2,20 @@ import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 
 import { AuthModule } from '#/auth/auth.module';
+import { SpreadSheetModule } from '#/spread-sheet/spread-sheet.module';
 import { UserModule } from '#/user/user.module';
 import { WordModule } from '#/word/word.module';
 import { QuizResult } from '#databases/entities/quizResult.entity';
+import { QuizSelection } from '#databases/entities/quizSelection.entity';
 import { QuizResultRepository } from '#databases/repositories/quizResult.repository';
 import { QuizSelectionRepository } from '#databases/repositories/quizSelection.repository';
 
 import { QuizController } from './quiz.controller';
 import { QuizService } from './quiz.service';
-import { SpreadSheetModule } from '#/spread-sheet/spread-sheet.module';
 
 @Module({
 	imports: [
-		TypeOrmModule.forFeature([QuizResult, QuizSelectionRepository]),
+		TypeOrmModule.forFeature([QuizResult, QuizSelection]),
 		AuthModule,
 		UserModule,
 		WordModule,

--- a/src/quiz/quiz.module.ts
+++ b/src/quiz/quiz.module.ts
@@ -6,16 +6,19 @@ import { UserModule } from '#/user/user.module';
 import { WordModule } from '#/word/word.module';
 import { QuizResult } from '#databases/entities/quizResult.entity';
 import { QuizResultRepository } from '#databases/repositories/quizResult.repository';
+import { QuizSelectionRepository } from '#databases/repositories/quizSelection.repository';
 
 import { QuizController } from './quiz.controller';
 import { QuizService } from './quiz.service';
+import { SpreadSheetModule } from '#/spread-sheet/spread-sheet.module';
 
 @Module({
 	imports: [
-		TypeOrmModule.forFeature([QuizResult]),
+		TypeOrmModule.forFeature([QuizResult, QuizSelectionRepository]),
 		AuthModule,
 		UserModule,
 		WordModule,
+		SpreadSheetModule,
 	],
 	controllers: [QuizController],
 	providers: [
@@ -23,6 +26,7 @@ import { QuizService } from './quiz.service';
 		QuizService,
 		// Repository
 		QuizResultRepository,
+		QuizSelectionRepository,
 	],
 })
 export class QuizModule {}

--- a/src/quiz/quiz.service.ts
+++ b/src/quiz/quiz.service.ts
@@ -1,4 +1,5 @@
 import { BadRequestException, Injectable } from '@nestjs/common';
+import { Cron, CronExpression } from '@nestjs/schedule';
 
 import { plainToInstance } from 'class-transformer';
 
@@ -129,10 +130,16 @@ export class QuizService {
 			const quizSelectionEntity = isExist
 				? await this.quizSelectionRepository.update(
 						quizSelectionId,
-						plainToInstance(RequestUpdateQuizSelectDto, quizSelectionInformation),
+						plainToInstance(
+							RequestUpdateQuizSelectDto,
+							quizSelectionInformation,
+						),
 					)
 				: await this.quizSelectionRepository.create(
-						plainToInstance(RequestCreateQuizSelectDto, quizSelectionInformation),
+						plainToInstance(
+							RequestCreateQuizSelectDto,
+							quizSelectionInformation,
+						),
 					);
 
 			if (!isExist) {
@@ -146,5 +153,13 @@ export class QuizService {
 		}
 
 		return true;
+	}
+
+	@Cron(CronExpression.EVERY_DAY_AT_MIDNIGHT, {
+		name: 'update-quiz-selections',
+		timeZone: 'Asia/Seoul',
+	})
+	async updateQuizSelectionListBatch() {
+		return await this.updateQuizSelectionList();
 	}
 }

--- a/src/quiz/quiz.service.ts
+++ b/src/quiz/quiz.service.ts
@@ -16,6 +16,7 @@ import {
 	RequestQuizResultDto,
 	ResponseQuizResultDto,
 } from './dto/quiz-result.dto';
+import { RequestUpdateQuizSelectDto } from './dto/update-quiz-selection.dto';
 
 @Injectable()
 export class QuizService {
@@ -128,7 +129,7 @@ export class QuizService {
 			const quizSelectionEntity = isExist
 				? await this.quizSelectionRepository.update(
 						quizSelectionId,
-						plainToInstance(RequestUpdateWordDto, quizSelectionInformation),
+						plainToInstance(RequestUpdateQuizSelectDto, quizSelectionInformation),
 					)
 				: await this.quizSelectionRepository.create(
 						plainToInstance(RequestCreateQuizSelectDto, quizSelectionInformation),

--- a/src/quiz/quiz.service.ts
+++ b/src/quiz/quiz.service.ts
@@ -21,6 +21,7 @@ import {
 	RequestQuizResultDto,
 	ResponseQuizResultDto,
 } from './dto/quiz-result.dto';
+import { ResponseQuizSelectionDto } from './dto/quiz-selection.dto';
 import { RequestUpdateQuizSelectDto } from './dto/update-quiz-selection.dto';
 
 @Injectable()
@@ -87,8 +88,8 @@ export class QuizService {
 						}),
 					)
 				: await this.quizSelectionRepository.create(
+						word,
 						plainToInstance(RequestCreateQuizSelectDto, {
-							wordId: word.id,
 							correct,
 							incorrectList,
 						}),
@@ -179,10 +180,6 @@ export class QuizService {
 		return responseQuizResultDto;
 	}
 
-	createQuizSelection(createQuizSelectionDto: RequestCreateQuizSelectDto) {
-		return this.quizSelectionRepository.create(createQuizSelectionDto);
-	}
-
 	async findQuizSelectionByWordId(wordId: string) {
 		const quizSelection =
 			await this.quizSelectionRepository.findByWordId(wordId);
@@ -194,5 +191,18 @@ export class QuizService {
 		}
 
 		return quizSelection;
+	}
+
+	async findQuizSelectionRandom() {
+		const quizSelectionList =
+			await this.quizSelectionRepository.findRandomQuizSelection();
+
+		const responseQuizSelectionDto = plainToInstance(
+			ResponseQuizSelectionDto,
+			quizSelectionList,
+			{ excludeExtraneousValues: true },
+		);
+
+		return responseQuizSelectionDto;
 	}
 }

--- a/src/quiz/quiz.service.ts
+++ b/src/quiz/quiz.service.ts
@@ -138,6 +138,7 @@ export class QuizService {
 			if (!isExist) {
 				const insertedCellLocation = `${this.SPREAD_SHEET_UUID_ROW}${index}`;
 				await this.spreadSheetService.insertCellData(
+					'quizSelection',
 					insertedCellLocation,
 					quizSelectionEntity.id,
 				);

--- a/src/spread-sheet/spread-sheet.service.ts
+++ b/src/spread-sheet/spread-sheet.service.ts
@@ -33,11 +33,11 @@ export class SpreadSheetService {
 		return google.sheets({ version: 'v4', auth: this.jwtClient });
 	}
 
-	async getRangeCellData(range: string) {
+	async getRangeCellData(sheetName: string, range: string) {
 		const sheets = this.getGoogleSheetConnect();
 		const rangeCells = await sheets.spreadsheets.values.get({
 			spreadsheetId: this.spreadSheetId,
-			range,
+			range: `${sheetName}-${process.env.NODE_ENV}!${range}`,
 		});
 
 		const rangeCellValues: string[][] = rangeCells.data.values ?? [];
@@ -45,11 +45,11 @@ export class SpreadSheetService {
 		return rangeCellValues;
 	}
 
-	async insertCellData(range: string, value: string) {
+	async insertCellData(sheetName: string, range: string, value: string) {
 		const sheets = this.getGoogleSheetConnect();
 		const response = await sheets.spreadsheets.values.update({
 			spreadsheetId: this.spreadSheetId,
-			range: `${process.env.NODE_ENV}!${range}`,
+			range: `${sheetName}-${process.env.NODE_ENV}!${range}`,
 			valueInputOption: 'RAW',
 			requestBody: {
 				values: [[value]],
@@ -60,8 +60,8 @@ export class SpreadSheetService {
 	}
 
 	async parseWordSpreadSheet() {
-		const spreadSheetRange = `${process.env.NODE_ENV}!A2:Z`;
-		const sheetCellList = await this.getRangeCellData(spreadSheetRange);
+		const spreadSheetRange = `word-${process.env.NODE_ENV}!A2:Z`;
+		const sheetCellList = await this.getRangeCellData('word', spreadSheetRange);
 
 		if (!sheetCellList?.length) return [];
 
@@ -105,7 +105,7 @@ export class SpreadSheetService {
 
 	async parseQuizSelectionSheet() {
 		const spreadSheetRange = `${process.env.NODE_ENV}-QuizSelection!A2:Z`;
-		const sheetCellList = await this.getRangeCellData(spreadSheetRange);
+		const sheetCellList = await this.getRangeCellData('quizSelection', spreadSheetRange);
 
 		if (!sheetCellList?.length) return [];
 

--- a/src/word/word.service.ts
+++ b/src/word/word.service.ts
@@ -62,8 +62,8 @@ export class WordService {
 		return true;
 	}
 
-	@Cron(CronExpression.EVERY_3_HOURS, {
-		name: 'update-spread-sheets',
+	@Cron(CronExpression.EVERY_12_HOURS, {
+		name: 'update-word-list',
 		timeZone: 'Asia/Seoul',
 	})
 	async updateWordListBatch() {

--- a/src/word/word.service.ts
+++ b/src/word/word.service.ts
@@ -23,56 +23,12 @@ export class WordService {
 	private SPREAD_SHEET_UUID_ROW = 'G';
 
 	/**
-	 * Google Spread SHeet 에서 단어 목록을 파싱하는 메서드 parseWordSpreadSheet
-	 */
-	private async parseWordSpreadSheet() {
-		const sheetCellList =
-			(await this.spreadSheetService.getRangeCellData()) ?? [];
-
-		if (!sheetCellList.length) return [];
-
-		const parseResult =
-			sheetCellList.map(
-				(
-					[
-						name,
-						description,
-						diacritic,
-						pronunciation,
-						wrongPronunciations,
-						exampleSentence,
-						uuid,
-					],
-					index,
-				) => {
-					const diacriticList = diacritic.split(',');
-					const pronunciationList = pronunciation
-						.split(',')
-						.map((word) => word.trim());
-					const wrongPronunciationList = wrongPronunciations
-						.split(',')
-						.map((word) => word.trim());
-					return {
-						name,
-						description,
-						diacritic: diacriticList,
-						pronunciation: pronunciationList,
-						wrongPronunciations: wrongPronunciationList,
-						exampleSentence,
-						uuid,
-						index: index + 2, // NOTE : SpreadSheet 의 경우 2번부터 단어 시작
-					};
-				},
-			) ?? [];
-
-		return parseResult;
-	}
-
-	/**
 	 * Spread Sheet 데이터를 파싱하여 DB 에 저장하는 매서드 updateWordList
 	 */
 	async updateWordList() {
-		const parsedSheetDataList = await this.parseWordSpreadSheet();
+		const parsedSheetDataList =
+			await this.spreadSheetService.parseWordSpreadSheet();
+
 		if (!parsedSheetDataList.length) return true;
 
 		for await (const {
@@ -94,8 +50,9 @@ export class WordService {
 					);
 
 			if (!isExist) {
+				const insertedCellLocation = `${this.SPREAD_SHEET_UUID_ROW}${index}`;
 				await this.spreadSheetService.insertCellData(
-					`${this.SPREAD_SHEET_UUID_ROW}${index}`,
+					insertedCellLocation,
 					wordEntity.id,
 				);
 			}

--- a/src/word/word.service.ts
+++ b/src/word/word.service.ts
@@ -21,7 +21,7 @@ export class WordService {
 	) {}
 
 	private SPREAD_SHEET_UUID_ROW = 'G';
-	private readonly SPREAD_SHEET_NAME = 'word'
+	private readonly SPREAD_SHEET_NAME = 'word';
 	private parseWordFromSpreadSheet = (
 		[
 			name,

--- a/src/word/word.service.ts
+++ b/src/word/word.service.ts
@@ -4,9 +4,9 @@ import { Cron, CronExpression } from '@nestjs/schedule';
 import { plainToInstance } from 'class-transformer';
 
 import { SpreadSheetService } from '#/spread-sheet/spread-sheet.service';
-import { RequestCreateUserDto } from '#/user/dto/create-user.dto';
 import { WordRepository } from '#databases/repositories/word.repository';
 
+import { RequestCreateWordDto } from './dto/create-word.dto';
 import { RequestUpdateWordDto } from './dto/update-word.dto';
 import { RequestWordDetailDto } from './dto/word-detail.dto';
 import { RequestWordListDto } from './dto/word-list.dto';
@@ -19,6 +19,8 @@ export class WordService {
 		private readonly wordRepository: WordRepository,
 		private readonly spreadSheetService: SpreadSheetService,
 	) {}
+
+	private SPREAD_SHEET_UUID_ROW = 'G';
 
 	/**
 	 * Google Spread SHeet 에서 단어 목록을 파싱하는 메서드 parseWordSpreadSheet
@@ -88,12 +90,12 @@ export class WordService {
 						plainToInstance(RequestUpdateWordDto, wordInformation),
 					)
 				: await this.wordRepository.create(
-						plainToInstance(RequestCreateUserDto, wordInformation),
+						plainToInstance(RequestCreateWordDto, wordInformation),
 					);
 
 			if (!isExist) {
 				await this.spreadSheetService.insertCellData(
-					`G${index}`,
+					`${this.SPREAD_SHEET_UUID_ROW}${index}`,
 					wordEntity.id,
 				);
 			}

--- a/src/word/word.service.ts
+++ b/src/word/word.service.ts
@@ -52,6 +52,7 @@ export class WordService {
 			if (!isExist) {
 				const insertedCellLocation = `${this.SPREAD_SHEET_UUID_ROW}${index}`;
 				await this.spreadSheetService.insertCellData(
+					'word',
 					insertedCellLocation,
 					wordEntity.id,
 				);


### PR DESCRIPTION
## Task Summary ✨
퀴즈 선택지 Schema 및 SpreadSheet 연동 기능 개발

## Description 📑
- 퀴즈 선택지 Schema 및 Repository 개발
- Google Spread Sheet 에서 단어 선택지 Cell 을 파싱하여 업데이트 / 신규 생성하는 로직 추가
- 하루를 주기로 Google Spread Sheet 를 파싱하는 Service 로직 별도 신설
- 생성된 퀴즈 선택기 중 10개를 무작위로 선정하여 사용자에게 제공하는 API 추가

## More Information 🛎
- Google Spread Sheet 와 서비스 로직이 강결합되었던 구조적 결함 일부 수정
- 단어 자동 갱신 주기를 기존의 3시간에서 12시간으로 증가

## Self Checklist ✅
- [ ] 코드 리뷰 요청
- [x] PR 제목 컨벤션에 맞는지 확인
- [x] PR Label 설정