### PR TITLE
[DEV-47] Swagger 공용 유틸 Decorator 제작 및 API 문서 고도화

### DIFF
--- a/src/common/decorators/swagger.decorator.ts
+++ b/src/common/decorators/swagger.decorator.ts
@@ -1,0 +1,114 @@
+import { HttpStatus, Type, applyDecorators } from '@nestjs/common';
+import {
+	ApiExtraModels,
+	ApiHeader,
+	ApiHeaderOptions,
+	ApiOperation,
+	ApiParam,
+	ApiParamOptions,
+	ApiQuery,
+	ApiQueryOptions,
+	ApiResponse,
+	getSchemaPath,
+} from '@nestjs/swagger';
+
+import { ApiResponseDto } from '../dto/apiResponse.dto';
+import { PaginationDto } from '../dto/pagination.dto';
+
+interface ApiDocsParams {
+	summary: string;
+	headers?: ApiHeaderOptions[] | ApiHeaderOptions;
+	params?: ApiParamOptions[] | ApiParamOptions;
+	query?: ApiQueryOptions[] | ApiQueryOptions;
+	response?: {
+		statusCode: HttpStatus;
+		schema: Type<any>;
+		isPaginated?: boolean;
+	};
+}
+
+export const ApiDocs = (apiDocs: ApiDocsParams) => {
+	const appliedDecorators = [
+		ApiOperation({
+			summary: apiDocs.summary,
+		}),
+	];
+
+	if (apiDocs.headers) {
+		Array.isArray(apiDocs.headers)
+			? apiDocs.headers.map((headerOption) =>
+					appliedDecorators.push(ApiHeader(headerOption)),
+				)
+			: appliedDecorators.push(ApiHeader(apiDocs.headers));
+	}
+
+	if (apiDocs.params) {
+		Array.isArray(apiDocs.params)
+			? apiDocs.params.map((paramOption) =>
+					appliedDecorators.push(ApiParam(paramOption)),
+				)
+			: appliedDecorators.push(ApiParam(apiDocs.params));
+	}
+
+	if (apiDocs.query) {
+		Array.isArray(apiDocs.query)
+			? apiDocs.query.map((queryOption) =>
+					appliedDecorators.push(ApiQuery(queryOption)),
+				)
+			: appliedDecorators.push(ApiQuery(apiDocs.query));
+	}
+
+	if (apiDocs.response) {
+		const { response } = apiDocs;
+		appliedDecorators.push(
+			ApiExtraModels(ApiResponseDto, PaginationDto, response.schema),
+		);
+		appliedDecorators.push(
+			ApiResponse({
+				status: response.statusCode,
+				content: {
+					'application/json': {
+						schema: {
+							allOf: [
+								{ $ref: getSchemaPath(ApiResponseDto) },
+								{
+									properties: {
+										data: response.isPaginated
+											? {
+													allOf: [
+														{
+															$ref: getSchemaPath(
+																PaginationDto,
+															),
+														},
+														{
+															properties: {
+																data: {
+																	type: 'array',
+																	items: {
+																		$ref: getSchemaPath(
+																			response.schema,
+																		),
+																	},
+																},
+															},
+														},
+													],
+												}
+											: {
+													$ref: getSchemaPath(
+														response.schema,
+													),
+												},
+									},
+								},
+							],
+						},
+					},
+				},
+			}),
+		);
+	}
+
+	return applyDecorators(...appliedDecorators);
+};

--- a/src/common/decorators/swagger.decorator.ts
+++ b/src/common/decorators/swagger.decorator.ts
@@ -1,5 +1,7 @@
 import { HttpStatus, Type, applyDecorators } from '@nestjs/common';
 import {
+	ApiBody,
+	ApiBodyOptions,
 	ApiExtraModels,
 	ApiHeader,
 	ApiHeaderOptions,
@@ -20,6 +22,7 @@ interface ApiDocsParams {
 	headers?: ApiHeaderOptions[] | ApiHeaderOptions;
 	params?: ApiParamOptions[] | ApiParamOptions;
 	query?: ApiQueryOptions[] | ApiQueryOptions;
+	body?: ApiBodyOptions;
 	response?: {
 		statusCode: HttpStatus;
 		schema: Type<any>;
@@ -56,6 +59,14 @@ export const ApiDocs = (apiDocs: ApiDocsParams) => {
 					appliedDecorators.push(ApiQuery(queryOption)),
 				)
 			: appliedDecorators.push(ApiQuery(apiDocs.query));
+	}
+
+	if (apiDocs.body) {
+		Array.isArray(apiDocs.body)
+			? apiDocs.body.map((bodyOption) =>
+					appliedDecorators.push(ApiBody(bodyOption)),
+				)
+			: appliedDecorators.push(ApiBody(apiDocs.body));
 	}
 
 	if (apiDocs.response) {

--- a/src/common/dto/apiResponse.dto.ts
+++ b/src/common/dto/apiResponse.dto.ts
@@ -1,0 +1,14 @@
+import { HttpStatus, Type } from '@nestjs/common';
+import { ApiProperty } from '@nestjs/swagger';
+
+export class ApiResponseDto<T extends Type<any>> {
+	@ApiProperty({
+		enum: HttpStatus,
+	})
+	code: number;
+
+	@ApiProperty({
+		type: 'generic',
+	})
+	data: T;
+}

--- a/src/common/dto/pagination.dto.ts
+++ b/src/common/dto/pagination.dto.ts
@@ -103,7 +103,7 @@ export class PaginationMetaDto {
 
 export class PaginationOptionDto {
 	@ApiProperty({
-		description: '조회할 페이지',
+		description: '데이터를 조회할 페이지',
 		type: Number,
 		required: false,
 		default: 1,
@@ -119,7 +119,7 @@ export class PaginationOptionDto {
 		description: '페이지 당 제공할 데이터 수량',
 		type: Number,
 		required: false,
-		default: 1,
+		default: 10,
 		minimum: 1,
 		maximum: 50,
 	})

--- a/src/databases/entities/user.entity.ts
+++ b/src/databases/entities/user.entity.ts
@@ -1,3 +1,5 @@
+import { ApiProperty } from '@nestjs/swagger';
+
 import {
 	Column,
 	CreateDateColumn,
@@ -13,18 +15,22 @@ import { Like } from './like.entity';
 @Entity({ name: 'user' })
 export class User {
 	@PrimaryColumn({ type: 'varchar', unique: true })
+	@ApiProperty()
 	id: string;
 
 	@Column({ type: 'varchar' })
+	@ApiProperty()
 	name: string;
 
 	@Column({ type: 'varchar' })
+	@ApiProperty()
 	profileImage: string;
 
 	@Column({
 		type: 'enum',
 		enum: ['kakao'],
 	})
+	@ApiProperty()
 	socialType: string;
 
 	@OneToMany(() => Like, (like) => like.user)

--- a/src/like/like.controller.ts
+++ b/src/like/like.controller.ts
@@ -1,8 +1,9 @@
 import { Controller, Delete, Param, Patch, UseGuards } from '@nestjs/common';
-import { ApiOperation, ApiParam, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { ApiTags } from '@nestjs/swagger';
 
 import { AuthenticatedUser } from '#/auth/decorator/auth.decorator';
 import { AuthenticationGuard } from '#/auth/guard/auth.guard';
+import { ApiDocs } from '#/common/decorators/swagger.decorator';
 import { User } from '#databases/entities/user.entity';
 
 import { RequestCreateLikeDto } from './dto/create-like.dto';
@@ -14,17 +15,13 @@ import { LikeService } from './like.service';
 export class LikeController {
 	constructor(private readonly likeService: LikeService) {}
 
-	@ApiOperation({
+	@ApiDocs({
 		summary: '특정 단어에 대한 좋아요 처리를 진행합니다.',
-	})
-	@ApiParam({
-		name: 'wordId',
-		required: true,
-		description: '좋아요를 누른 단어 ID',
-	})
-	@ApiResponse({
-		status: 200,
-		description: '요청 성공시',
+		params: {
+			name: 'wordId',
+			required: true,
+			description: '좋아요를 누른 Word UUID (id)',
+		},
 	})
 	@Patch(':wordId')
 	@UseGuards(AuthenticationGuard)
@@ -35,17 +32,13 @@ export class LikeController {
 		return this.likeService.applyUserLike(createLikeDto, user);
 	}
 
-	@ApiOperation({
+	@ApiDocs({
 		summary: '특정 단어에 대한 좋아요 취소를 진행합니다.',
-	})
-	@ApiParam({
-		name: 'wordId',
-		required: true,
-		description: '좋아요를 취소한 단어 ID',
-	})
-	@ApiResponse({
-		status: 200,
-		description: '요청 성공시',
+		params: {
+			name: 'wordId',
+			required: true,
+			description: '좋아요를 취소한 Word UUID (id)',
+		},
 	})
 	@Delete(':wordId')
 	@UseGuards(AuthenticationGuard)

--- a/src/quiz/dto/create-quiz-result.dto.ts
+++ b/src/quiz/dto/create-quiz-result.dto.ts
@@ -1,4 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
+
 import { Expose, Transform } from 'class-transformer';
 import { IsArray, IsUUID, MaxLength } from 'class-validator';
 

--- a/src/quiz/dto/create-quiz-result.dto.ts
+++ b/src/quiz/dto/create-quiz-result.dto.ts
@@ -1,3 +1,4 @@
+import { ApiProperty } from '@nestjs/swagger';
 import { Expose, Transform } from 'class-transformer';
 import { IsArray, IsUUID, MaxLength } from 'class-validator';
 
@@ -8,11 +9,13 @@ export class RequestCreateQuizResultDto {
 	@IsArray()
 	@IsUUID()
 	@MaxLength(10)
+	@ApiProperty()
 	correctWordIds: string[];
 
 	@IsArray()
 	@IsUUID()
 	@MaxLength(10)
+	@ApiProperty()
 	incorrectWordIds: string[];
 }
 
@@ -20,17 +23,20 @@ export class ResponseCreateQuizResultDto {
 	@IsUUID()
 	@Transform(({ obj }) => obj.id)
 	@Expose()
+	@ApiProperty()
 	userId: string;
 
 	@IsArray()
 	@IsUUID()
 	@MaxLength(10)
 	@Expose()
+	@ApiProperty()
 	correctWordIds: string[];
 
 	@IsArray()
 	@IsUUID()
 	@MaxLength(10)
 	@Expose()
+	@ApiProperty()
 	incorrectWordIds: string[];
 }

--- a/src/quiz/dto/quiz-result.dto.ts
+++ b/src/quiz/dto/quiz-result.dto.ts
@@ -1,3 +1,4 @@
+import { ApiProperty } from '@nestjs/swagger';
 import { Expose, Transform, Type } from 'class-transformer';
 import {
 	IsBoolean,
@@ -46,17 +47,21 @@ class QuizResultWord {
 export class ResponseQuizResultDto {
 	@IsUUID()
 	@Expose()
+	@ApiProperty()
 	quizResultId: string;
 
 	@IsNumber()
 	@Expose()
+	@ApiProperty()
 	score: number;
 
 	@Type(() => QuizResultWord)
 	@Expose({ name: 'correctWords' })
+	@ApiProperty()
 	correctWords: QuizResultWord[];
 
 	@Type(() => QuizResultWord)
 	@Expose({ name: 'incorrectWords' })
+	@ApiProperty()
 	incorrectWords: QuizResultWord[];
 }

--- a/src/quiz/dto/quiz-result.dto.ts
+++ b/src/quiz/dto/quiz-result.dto.ts
@@ -1,4 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
+
 import { Expose, Transform, Type } from 'class-transformer';
 import {
 	IsBoolean,

--- a/src/quiz/dto/quiz-selection.dto.ts
+++ b/src/quiz/dto/quiz-selection.dto.ts
@@ -1,4 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
+
 import { Expose, Transform } from 'class-transformer';
 import { IsArray, IsString } from 'class-validator';
 

--- a/src/quiz/dto/quiz-selection.dto.ts
+++ b/src/quiz/dto/quiz-selection.dto.ts
@@ -1,3 +1,4 @@
+import { ApiProperty } from '@nestjs/swagger';
 import { Expose, Transform } from 'class-transformer';
 import { IsArray, IsString } from 'class-validator';
 
@@ -5,6 +6,7 @@ export class ResponseQuizSelectionDto {
 	@IsString()
 	@Transform(({ obj }) => obj.quizSelection_correct)
 	@Expose()
+	@ApiProperty()
 	correct: string;
 
 	@IsArray()
@@ -13,20 +15,24 @@ export class ResponseQuizSelectionDto {
 		obj.quizSelection_correct,
 	])
 	@Expose({ name: 'selections' })
+	@ApiProperty()
 	selections: string[];
 
 	@IsString()
 	@Transform(({ obj }) => obj.word_id)
 	@Expose()
+	@ApiProperty()
 	wordId: string;
 
 	@IsString()
 	@Transform(({ obj }) => obj.word_name)
 	@Expose()
+	@ApiProperty()
 	name: string;
 
 	@IsString()
 	@Transform(({ obj }) => obj.word_diacritic[0])
 	@Expose()
+	@ApiProperty()
 	diacritic: string;
 }

--- a/src/quiz/quiz.controller.ts
+++ b/src/quiz/quiz.controller.ts
@@ -2,28 +2,46 @@ import {
 	Body,
 	Controller,
 	Get,
+	HttpStatus,
 	Param,
 	Patch,
 	Post,
 	UseGuards,
 	UseInterceptors,
 } from '@nestjs/common';
+import { ApiTags } from '@nestjs/swagger';
 
 import { plainToInstance } from 'class-transformer';
 
 import { AuthenticatedUser } from '#/auth/decorator/auth.decorator';
 import { AuthenticationGuard } from '#/auth/guard/auth.guard';
+import { ApiDocs } from '#/common/decorators/swagger.decorator';
 import { UserInformationInterceptor } from '#/user/interceptors/user-information.interceptor';
 import { User } from '#databases/entities/user.entity';
 
-import { RequestCreateQuizResultDto } from './dto/create-quiz-result.dto';
-import { RequestQuizResultDto } from './dto/quiz-result.dto';
+import {
+	RequestCreateQuizResultDto,
+	ResponseCreateQuizResultDto,
+} from './dto/create-quiz-result.dto';
+import { RequestQuizResultDto, ResponseQuizResultDto } from './dto/quiz-result.dto';
 import { QuizService } from './quiz.service';
+import { ResponseQuizSelectionDto } from './dto/quiz-selection.dto';
 
+@ApiTags('Quiz')
 @Controller('quiz')
 export class QuizController {
 	constructor(private readonly quizService: QuizService) {}
 
+	@ApiDocs({
+		summary: '사용자가 풀이한 퀴즈 결과를 저장합니다.',
+		body: {
+			type: RequestCreateQuizResultDto,
+		},
+		response: {
+			statusCode: HttpStatus.CREATED,
+			schema: ResponseCreateQuizResultDto,
+		},
+	})
 	@UseGuards(AuthenticationGuard)
 	@Post('/result')
 	async createQuizResult(
@@ -38,6 +56,18 @@ export class QuizController {
 		return this.quizService.createQuizResult(createQuizResultDto);
 	}
 
+	@ApiDocs({
+		summary: '특정 ID 에 대한 퀴즈 결과 데이터를 조회합니다.',
+		params: {
+			name: 'quizResultId',
+			required: true,
+			description: '조회할 퀴즈 결과 UUID (id)',
+		},
+		response: {
+			statusCode: HttpStatus.OK,
+			schema: ResponseQuizResultDto,
+		},
+	})
 	@UseInterceptors(UserInformationInterceptor)
 	@Get('/result/:quizResultId')
 	async findQuizResultById(
@@ -52,11 +82,27 @@ export class QuizController {
 		return this.quizService.findQuizResultById(quizResultDto);
 	}
 
+	@ApiDocs({
+		summary: '생성된 퀴즈들 중 무작위로 10개를 선정합니다.',
+		response: {
+			statusCode: HttpStatus.OK,
+			schema: ResponseQuizSelectionDto,
+		},
+	})
 	@Get('/selection')
 	findQuizSelectionRandom() {
 		return this.quizService.findQuizSelectionRandom();
 	}
 
+	@ApiDocs({
+		summary:
+			'데브말싸미 Google Spread Sheet 를 기반으로 퀴즈 목록을 갱신합니다.',
+		headers: {
+			name: 'Authorization',
+			required: true,
+			description: '어드민 전용 Api Key',
+		},
+	})
 	@UseGuards(AuthenticationGuard)
 	@Patch('/selection/spread-sheet')
 	patchUpdateSpreadSheet() {

--- a/src/quiz/quiz.controller.ts
+++ b/src/quiz/quiz.controller.ts
@@ -23,9 +23,12 @@ import {
 	RequestCreateQuizResultDto,
 	ResponseCreateQuizResultDto,
 } from './dto/create-quiz-result.dto';
-import { RequestQuizResultDto, ResponseQuizResultDto } from './dto/quiz-result.dto';
-import { QuizService } from './quiz.service';
+import {
+	RequestQuizResultDto,
+	ResponseQuizResultDto,
+} from './dto/quiz-result.dto';
 import { ResponseQuizSelectionDto } from './dto/quiz-selection.dto';
+import { QuizService } from './quiz.service';
 
 @ApiTags('Quiz')
 @Controller('quiz')

--- a/src/user/dto/change-nickname.dto.ts
+++ b/src/user/dto/change-nickname.dto.ts
@@ -5,13 +5,13 @@ import { IsNotEmpty, IsUUID } from 'class-validator';
 export class RequestChangeNicknameDto {
 	@IsUUID()
 	@ApiProperty({
-		description: '수정하고자 하는 User UUID'
+		description: '수정하고자 하는 User UUID',
 	})
 	userId: string;
 
 	@IsNotEmpty()
 	@ApiProperty({
-		description: '새롭게 적용할 유저 닉네임'
+		description: '새롭게 적용할 유저 닉네임',
 	})
 	nickname: string;
 }

--- a/src/user/dto/change-nickname.dto.ts
+++ b/src/user/dto/change-nickname.dto.ts
@@ -1,9 +1,17 @@
+import { ApiProperty } from '@nestjs/swagger';
+
 import { IsNotEmpty, IsUUID } from 'class-validator';
 
 export class RequestChangeNicknameDto {
 	@IsUUID()
+	@ApiProperty({
+		description: '수정하고자 하는 User UUID'
+	})
 	userId: string;
 
 	@IsNotEmpty()
+	@ApiProperty({
+		description: '새롭게 적용할 유저 닉네임'
+	})
 	nickname: string;
 }

--- a/src/user/dto/user-information.dto.ts
+++ b/src/user/dto/user-information.dto.ts
@@ -1,4 +1,4 @@
-import { ApiProperty } from "@nestjs/swagger";
+import { ApiProperty } from '@nestjs/swagger';
 
 export class ResponseUserInformationDto {
 	@ApiProperty()
@@ -12,7 +12,7 @@ export class ResponseUserInformationDto {
 
 	@ApiProperty()
 	socialType: string;
-	
+
 	@ApiProperty()
 	createdAt: Date;
 

--- a/src/user/dto/user-information.dto.ts
+++ b/src/user/dto/user-information.dto.ts
@@ -1,8 +1,21 @@
+import { ApiProperty } from "@nestjs/swagger";
+
 export class ResponseUserInformationDto {
+	@ApiProperty()
 	id: string;
+
+	@ApiProperty()
 	name: string;
+
+	@ApiProperty()
 	profileImage: string;
+
+	@ApiProperty()
 	socialType: string;
+	
+	@ApiProperty()
 	createdAt: Date;
+
+	@ApiProperty()
 	updatedAt: Date;
 }

--- a/src/user/user.controller.ts
+++ b/src/user/user.controller.ts
@@ -1,8 +1,17 @@
-import { Body, Controller, Get, Param, Patch, UseGuards } from '@nestjs/common';
-import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
+import {
+	Body,
+	Controller,
+	Get,
+	HttpStatus,
+	Param,
+	Patch,
+	UseGuards,
+} from '@nestjs/common';
+import { ApiTags } from '@nestjs/swagger';
 
 import { AuthenticatedUser } from '#/auth/decorator/auth.decorator';
 import { AuthenticationGuard } from '#/auth/guard/auth.guard';
+import { ApiDocs } from '#/common/decorators/swagger.decorator';
 import { User } from '#databases/entities/user.entity';
 
 import { RequestChangeNicknameDto } from './dto/change-nickname.dto';
@@ -14,18 +23,12 @@ import { UserService } from './user.service';
 export class UserController {
 	constructor(private readonly userService: UserService) {}
 
-	@ApiOperation({
+	@ApiDocs({
 		summary: '자기 자신의 유저 정보를 열람합니다',
-	})
-	@ApiResponse({
-		status: 200,
-		description: '요청 성공 시 받을 응답',
-		type: ResponseUserInformationDto,
-	})
-	@ApiResponse({
-		status: 200,
-		description: '요청 성공 시',
-		type: User,
+		response: {
+			statusCode: HttpStatus.OK,
+			schema: User,
+		},
 	})
 	@Get()
 	@UseGuards(AuthenticationGuard)
@@ -34,25 +37,25 @@ export class UserController {
 		return this.userService.getUserInformation(userId);
 	}
 
-	@ApiOperation({
+	@ApiDocs({
 		summary: '특정 ID 를 가진 유저 정보를 조회합니다',
-	})
-	@ApiResponse({
-		status: 200,
-		description: '요청 성공 시',
-		type: User,
+		params: {
+			name: 'userId',
+			required: true,
+			description: '조회할 유저 UUID (id)',
+		},
+		response: {
+			statusCode: HttpStatus.OK,
+			schema: ResponseUserInformationDto,
+		},
 	})
 	@Get(':userId')
 	getUserInformation(@Param('userId') userId: string) {
 		return this.userService.getUserInformation(userId);
 	}
 
-	@ApiOperation({
+	@ApiDocs({
 		summary: '특정 ID 를 가진 유저의 닉네임을 수정합니다',
-	})
-	@ApiResponse({
-		status: 200,
-		description: '요청 성공 시 받을 응답',
 	})
 	@Patch('/nickname')
 	patchChangeNickname(

--- a/src/word/dto/word-detail.dto.ts
+++ b/src/word/dto/word-detail.dto.ts
@@ -1,3 +1,5 @@
+import { ApiProperty } from '@nestjs/swagger';
+
 import { Expose, Transform } from 'class-transformer';
 import {
 	IsArray,
@@ -21,45 +23,54 @@ export class ResponseWordDetailDto {
 	@IsUUID()
 	@Transform(({ obj }) => obj.word_id)
 	@Expose({ name: 'id' })
+	@ApiProperty()
 	id: string;
 
 	@IsString()
 	@Transform(({ obj }) => obj.word_name)
 	@Expose({ name: 'name' })
+	@ApiProperty()
 	name: string;
 
 	@IsString()
 	@Transform(({ obj }) => obj.word_description)
 	@Expose({ name: 'description' })
+	@ApiProperty()
 	description: string;
 
 	@IsArray()
 	@Transform(({ obj }) => obj.word_diacritic)
 	@Expose({ name: 'diacritic' })
+	@ApiProperty()
 	diacritic: string[];
 
 	@IsArray()
 	@Transform(({ obj }) => obj.word_pronunciation)
 	@Expose({ name: 'pronunciation' })
+	@ApiProperty()
 	pronunciation: string[];
 
 	@IsArray()
 	@Transform(({ obj }) => obj.word_wrongPronunciations)
 	@Expose({ name: 'wrongPronunciation' })
+	@ApiProperty()
 	wrongPronunciation: string[];
 
 	@IsString()
 	@Transform(({ obj }) => obj.word_exampleSentence)
 	@Expose({ name: 'exampleSentence' })
+	@ApiProperty()
 	exampleSentence: string;
 
 	@IsBoolean()
 	@Transform(({ obj }) => obj.islike)
 	@Expose({ name: 'isLike' })
+	@ApiProperty()
 	isLike: boolean;
 
 	@IsNumber()
 	@Transform(({ obj }) => Number(obj.likecount))
 	@Expose({ name: 'likeCount' })
+	@ApiProperty()
 	likeCount: number;
 }

--- a/src/word/dto/word-list.dto.ts
+++ b/src/word/dto/word-list.dto.ts
@@ -1,3 +1,5 @@
+import { ApiProperty } from '@nestjs/swagger';
+
 import { Expose, Transform } from 'class-transformer';
 import {
 	IsArray,
@@ -19,30 +21,36 @@ export class ResponseWordListDto {
 	@IsUUID()
 	@Transform(({ obj }) => obj.word_id)
 	@Expose({ name: 'id' })
+	@ApiProperty()
 	id: string;
 
 	@IsString()
 	@Transform(({ obj }) => obj.word_name)
 	@Expose({ name: 'name' })
+	@ApiProperty()
 	name: string;
 
 	@IsString()
 	@Transform(({ obj }) => obj.word_description)
 	@Expose({ name: 'description' })
+	@ApiProperty()
 	description: string;
 
 	@IsArray()
 	@Transform(({ obj }) => obj.word_diacritic)
 	@Expose({ name: 'diacritic' })
+	@ApiProperty()
 	diacritic: string[];
 
 	@IsArray()
 	@Transform(({ obj }) => obj.word_pronunciation)
 	@Expose({ name: 'pronunciation' })
+	@ApiProperty()
 	pronunciation: string[];
 
 	@IsBoolean()
 	@Transform(({ obj }) => obj.islike)
 	@Expose({ name: 'isLike' })
+	@ApiProperty()
 	isLike: boolean;
 }

--- a/src/word/dto/word-search.dto.ts
+++ b/src/word/dto/word-search.dto.ts
@@ -1,5 +1,8 @@
+import { ApiProperty } from '@nestjs/swagger';
+
 import { Expose, Transform } from 'class-transformer';
 import {
+	IsAlpha,
 	IsArray,
 	IsBoolean,
 	IsOptional,
@@ -16,7 +19,13 @@ export class RequestWordSearchDto extends PaginationOptionDto {
 	userId?: string;
 
 	@IsString()
+	@IsAlpha()
 	@MinLength(3)
+	@ApiProperty({
+		description: '검색할 단어 키워드',
+		type: String,
+		minLength: 3,
+	})
 	keyword: string;
 }
 
@@ -24,30 +33,56 @@ export class ResponseWordSearchDto {
 	@IsUUID()
 	@Transform(({ obj }) => obj.word_id)
 	@Expose({ name: 'id' })
+	@ApiProperty({
+		description: '단어 Id',
+		type: String,
+	})
 	id: string;
 
 	@IsString()
 	@Transform(({ obj }) => obj.word_name)
 	@Expose({ name: 'name' })
+	@ApiProperty({
+		description: '단어 명',
+		type: String,
+	})
 	name: string;
 
 	@IsString()
 	@Transform(({ obj }) => obj.word_description)
 	@Expose({ name: 'description' })
+	@ApiProperty({
+		description: '단어 설명',
+		type: String,
+	})
 	description: string;
 
 	@IsArray()
 	@Transform(({ obj }) => obj.word_diacritic)
 	@Expose({ name: 'diacritic' })
+	@ApiProperty({
+		description: '단어 발음 기호',
+		type: String,
+		isArray: true,
+	})
 	diacritic: string[];
 
 	@IsArray()
 	@Transform(({ obj }) => obj.word_pronunciation)
 	@Expose({ name: 'pronunciation' })
+	@ApiProperty({
+		description: '올바른 발음 목록',
+		type: String,
+		isArray: true,
+	})
 	pronunciation: string[];
 
 	@IsBoolean()
 	@Transform(({ obj }) => obj.islike)
 	@Expose({ name: 'isLike' })
+	@ApiProperty({
+		description: '유저 좋아요 여부 (비로그인 일 시 false)',
+		type: Boolean,
+	})
 	isLike: boolean;
 }

--- a/src/word/dto/word-user-like.dto.ts
+++ b/src/word/dto/word-user-like.dto.ts
@@ -1,8 +1,9 @@
+import { ApiProperty } from '@nestjs/swagger';
+
 import { Exclude } from 'class-transformer';
 import { IsArray, IsString, IsUUID } from 'class-validator';
 
 import { PaginationOptionDto } from '#/common/dto/pagination.dto';
-import { ApiProperty } from '@nestjs/swagger';
 
 export class RequestWordUserLikeDto extends PaginationOptionDto {
 	@IsUUID()
@@ -31,14 +32,14 @@ export class ResponseWordUserLikeDto {
 	@IsArray()
 	@ApiProperty({
 		type: String,
-		isArray: true
+		isArray: true,
 	})
 	diacritic: string[];
 
 	@IsArray()
 	@ApiProperty({
 		type: String,
-		isArray: true
+		isArray: true,
 	})
 	pronunciation: string[];
 

--- a/src/word/dto/word-user-like.dto.ts
+++ b/src/word/dto/word-user-like.dto.ts
@@ -2,6 +2,7 @@ import { Exclude } from 'class-transformer';
 import { IsArray, IsString, IsUUID } from 'class-validator';
 
 import { PaginationOptionDto } from '#/common/dto/pagination.dto';
+import { ApiProperty } from '@nestjs/swagger';
 
 export class RequestWordUserLikeDto extends PaginationOptionDto {
 	@IsUUID()
@@ -10,18 +11,35 @@ export class RequestWordUserLikeDto extends PaginationOptionDto {
 
 export class ResponseWordUserLikeDto {
 	@IsUUID()
+	@ApiProperty({
+		type: String,
+	})
 	id: string;
 
 	@IsString()
+	@ApiProperty({
+		type: String,
+	})
 	name: string;
 
 	@IsString()
+	@ApiProperty({
+		type: String,
+	})
 	description: string;
 
 	@IsArray()
+	@ApiProperty({
+		type: String,
+		isArray: true
+	})
 	diacritic: string[];
 
 	@IsArray()
+	@ApiProperty({
+		type: String,
+		isArray: true
+	})
 	pronunciation: string[];
 
 	@Exclude()


### PR DESCRIPTION
## Task Summary ✨
 Swagger 공용 유틸 Decorator 제작 및 API 문서 고도화

## Description 📑
- ApiBody, ApiQuery, ApiOperator 등 Swagger 에서 쓰이는 데코레이터를 하나로 합친 ApiDocs 를 제작했습니다.
- Pagination 여부에 따라서 다른 데이터 구조를 가지도록 조건부 처리를 Decorator 내부에서 진행하는 로직을 추가했습니다.
- Quiz, Word, User 와 관련된 Swagger API 문서에서 Response Type 이 정상적으로 출력되도록 수정했습니다.

## Self Checklist ✅
- [x] 코드 리뷰 요청
- [x] PR 제목 컨벤션에 맞는지 확인
- [x] PR Label 설정