### PR TITLE
[DEV-48] 에러 발생 시 Discord Webhook Embed 메세지 전송

### DIFF
--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -99,6 +99,7 @@ jobs:
           echo "GOOGLE_SPREAD_SHEET_ID=${{ secrets.GOOGLE_SPREAD_SHEET_ID }}" >> .env.production
           echo "SERVER_PORT=${{ secrets.SERVER_PORT }}" >> .env.production
           echo "TEST_ADMIN_KEY"=${{ secrets.TEST_ADMIN_KEY }} >> .env.production
+          echo "DISCORD_WEBHOOK_URL"=${{ secrets.DISCORD_WEBHOOK_URL }} >> .env.production
 
           sudo docker pull ${{ secrets.DOCKER_HUB_USERNAME }}/devminjeong-eum-backend:latest
           sudo docker run -p 8080:8080 \

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -13,11 +13,11 @@ import { LoggerMiddleware } from '#middlewares/logger.middleware';
 
 import { AppController } from './app.controller';
 import { AuthModule } from './auth/auth.module';
+import { DiscordWebhookModule } from './discord/discord.module';
 import { LikeModule } from './like/like.module';
 import { QuizModule } from './quiz/quiz.module';
 import { UserModule } from './user/user.module';
 import { WordModule } from './word/word.module';
-import { DiscordWebhookModule } from './discord/discord.module';
 
 @Module({
 	imports: [

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -17,6 +17,7 @@ import { LikeModule } from './like/like.module';
 import { QuizModule } from './quiz/quiz.module';
 import { UserModule } from './user/user.module';
 import { WordModule } from './word/word.module';
+import { DiscordWebhookModule } from './discord/discord.module';
 
 @Module({
 	imports: [
@@ -28,6 +29,7 @@ import { WordModule } from './word/word.module';
 			useClass: TypeOrmConfig,
 		}),
 		ScheduleModule.forRoot(),
+		DiscordWebhookModule,
 		UserModule,
 		AuthModule,
 		WordModule,

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -1,11 +1,45 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, InternalServerErrorException } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
 import { JwtService } from '@nestjs/jwt';
+
+import type { Request, Response } from 'express';
+
+import { UserRepository } from '#databases/repositories/user.repository';
 
 import type { JwtPayload } from './interface/jwt-auth.interface';
 
 @Injectable()
 export class AuthService {
-	constructor(private readonly jwtService: JwtService) {}
+	constructor(
+		private readonly jwtService: JwtService,
+		private readonly configService: ConfigService,
+		private readonly userRepository: UserRepository,
+	) {}
+
+	private cookieOption = {
+		secure: true,
+		sameSite: 'none',
+		path: '/',
+	} as const;
+
+	async checkIsAdminRequest(request: Request) {
+		const { authorization: requestAdminKey } = request.headers;
+		const adminKey = this.configService.get<string>('TEST_ADMIN_KEY');
+
+		const isAdminRequest =
+			requestAdminKey && adminKey && requestAdminKey === adminKey;
+
+		if (!isAdminRequest) return undefined;
+
+		const adminUser = await this.userRepository.findById(adminKey);
+
+		if (!adminUser)
+			throw new InternalServerErrorException(
+				'Admin User 정보가 DB 에 존재하지 않습니다. 관리자에게 문의하세요.',
+			);
+
+		return adminUser;
+	}
 
 	getAuthenticateToken(userId: string) {
 		const payload = { id: userId };
@@ -18,5 +52,50 @@ export class AuthService {
 	async verifyAuthenticateToken(token: string) {
 		const payload = await this.jwtService.verifyAsync<JwtPayload>(token);
 		return payload.id;
+	}
+
+	async reIssueAuthenticateToken(response: Response, refreshToken: string) {
+		try {
+			const userId = await this.verifyAuthenticateToken(refreshToken);
+			const {
+				accessToken: reIssueAccessToken,
+				refreshToken: reIssueRefreshToken,
+			} = this.getAuthenticateToken(userId);
+
+			this.setAuthenticateCookie(
+				response,
+				reIssueAccessToken,
+				reIssueRefreshToken,
+			);
+			return userId;
+		} catch (error) {
+			this.removeAuthenticateCookie(response);
+		}
+	}
+
+	setAuthenticateCookie(
+		response: Response,
+		accessToken: string,
+		refreshToken: string,
+	) {
+		response.cookie('accessToken', accessToken, {
+			...this.cookieOption,
+			maxAge: 5 * 60 * 1000, // NOTE : 5H
+		});
+		response.cookie('refreshToken', refreshToken, {
+			...this.cookieOption,
+			maxAge: 7 * 24 * 60 * 60 * 1000, // NOTE : 7D
+		});
+	}
+
+	removeAuthenticateCookie(response: Response) {
+		response.cookie('accessToken', '', {
+			...this.cookieOption,
+			maxAge: 0,
+		});
+		response.cookie('refreshToken', '', {
+			...this.cookieOption,
+			maxAge: 0,
+		});
 	}
 }

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -23,7 +23,7 @@ export class AuthService {
 	} as const;
 
 	private readonly ACCESS_TOKEN_MAX_AGE = 5 * 60 * 1000;
-	private readonly REFRESH_TOKEN_MAX_AGE =  7 * 24 * 60 * 60 * 1000;
+	private readonly REFRESH_TOKEN_MAX_AGE = 7 * 24 * 60 * 60 * 1000;
 
 	async checkIsAdminRequest(request: Request) {
 		const { authorization: requestAdminKey } = request.headers;

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -22,6 +22,9 @@ export class AuthService {
 		path: '/',
 	} as const;
 
+	private readonly ACCESS_TOKEN_MAX_AGE = 5 * 60 * 1000;
+	private readonly REFRESH_TOKEN_MAX_AGE =  7 * 24 * 60 * 60 * 1000;
+
 	async checkIsAdminRequest(request: Request) {
 		const { authorization: requestAdminKey } = request.headers;
 		const adminKey = this.configService.get<string>('TEST_ADMIN_KEY');
@@ -80,11 +83,11 @@ export class AuthService {
 	) {
 		response.cookie('accessToken', accessToken, {
 			...this.cookieOption,
-			maxAge: 5 * 60 * 1000, // NOTE : 5H
+			maxAge: this.ACCESS_TOKEN_MAX_AGE,
 		});
 		response.cookie('refreshToken', refreshToken, {
 			...this.cookieOption,
-			maxAge: 7 * 24 * 60 * 60 * 1000, // NOTE : 7D
+			maxAge: this.REFRESH_TOKEN_MAX_AGE,
 		});
 	}
 

--- a/src/auth/guard/auth.guard.ts
+++ b/src/auth/guard/auth.guard.ts
@@ -48,7 +48,9 @@ export class AuthenticationGuard implements CanActivate {
 			);
 
 		if (!userId) {
-			throw new UnauthorizedException('유저 정보가 만료되었습니다. 로그인을 진행해주세요.')
+			throw new UnauthorizedException(
+				'유저 정보가 만료되었습니다. 로그인을 진행해주세요.',
+			);
 		}
 
 		const user = await this.userRepository.findById(userId);

--- a/src/auth/guard/auth.guard.ts
+++ b/src/auth/guard/auth.guard.ts
@@ -3,47 +3,29 @@ import {
 	CanActivate,
 	ExecutionContext,
 	Injectable,
-	InternalServerErrorException,
 	UnauthorizedException,
 } from '@nestjs/common';
-import { ConfigService } from '@nestjs/config';
 
 import type { Response } from 'express';
 
+import { AuthService } from '#/auth/auth.service';
 import { UserRepository } from '#databases/repositories/user.repository';
-
-import { AuthService } from '../auth.service';
 
 @Injectable()
 export class AuthenticationGuard implements CanActivate {
 	constructor(
 		private readonly authService: AuthService,
-		private readonly configService: ConfigService,
 		private readonly userRepository: UserRepository,
 	) {}
-
-	private cookieOption = {
-		secure: true,
-		sameSite: 'none',
-		path: '/',
-	} as const;
 
 	async canActivate(context: ExecutionContext) {
 		const request = context.switchToHttp().getRequest();
 		const response = context.switchToHttp().getResponse<Response>();
 
 		// NOTE : 원활한 개발을 위해 임시로 생성한 Admin 계정에 접근 가능하도록 하는 Key
-		const { authorization: requestAdminKey } = request.headers;
-		const adminKey = this.configService.get<string>('TEST_ADMIN_KEY');
+		const adminUser = await this.authService.checkIsAdminRequest(request);
 
-		if (requestAdminKey && adminKey && requestAdminKey === adminKey) {
-			const adminUser = await this.userRepository.findById(adminKey);
-
-			if (!adminUser)
-				throw new InternalServerErrorException(
-					'Admin User 정보가 DB 에 존재하지 않습니다. 관리자에게 문의하세요.',
-				);
-
+		if (adminUser) {
 			request.user = adminUser;
 			return true;
 		}
@@ -58,65 +40,25 @@ export class AuthenticationGuard implements CanActivate {
 
 		const userId = await this.authService
 			.verifyAuthenticateToken(accessToken)
-			.catch(() => this.checkRefreshToken(response, refreshToken));
+			.catch(() =>
+				this.authService.reIssueAuthenticateToken(
+					response,
+					refreshToken,
+				),
+			);
+
+		if (!userId) {
+			throw new UnauthorizedException('유저 정보가 만료되었습니다. 로그인을 진행해주세요.')
+		}
 
 		const user = await this.userRepository.findById(userId);
 
 		if (!user) {
-			this.removeAuthenticateCookie(response);
+			this.authService.removeAuthenticateCookie(response);
 			throw new BadRequestException('유효하지 않은 계정 정보입니다.');
 		}
 
 		request.user = user;
 		return true;
-	}
-
-	private async checkRefreshToken(response: Response, refreshToken: string) {
-		try {
-			const userId =
-				await this.authService.verifyAuthenticateToken(refreshToken);
-			const {
-				accessToken: reIssueAccessToken,
-				refreshToken: reIssueRefreshToken,
-			} = this.authService.getAuthenticateToken(userId);
-
-			this.setAuthenticateCookie(
-				response,
-				reIssueAccessToken,
-				reIssueRefreshToken,
-			);
-			return userId;
-		} catch (error) {
-			this.removeAuthenticateCookie(response);
-			throw new UnauthorizedException(
-				'토큰이 만료되었습니다. 다시 로그인해주세요.',
-			);
-		}
-	}
-
-	private setAuthenticateCookie(
-		response: Response,
-		accessToken: string,
-		refreshToken: string,
-	) {
-		response.cookie('accessToken', accessToken, {
-			...this.cookieOption,
-			maxAge: 5 * 60 * 1000, // NOTE : 5H
-		});
-		response.cookie('refreshToken', refreshToken, {
-			...this.cookieOption,
-			maxAge: 7 * 24 * 60 * 60 * 1000, // NOTE : 7D
-		});
-	}
-
-	private removeAuthenticateCookie(response: Response) {
-		response.cookie('accessToken', '', {
-			...this.cookieOption,
-			maxAge: 0,
-		});
-		response.cookie('refreshToken', '', {
-			...this.cookieOption,
-			maxAge: 0,
-		});
 	}
 }

--- a/src/common/configs/setup.config.ts
+++ b/src/common/configs/setup.config.ts
@@ -16,7 +16,7 @@ export const setupNestApplication = (app: INestApplication) => {
 
 	/**
 	 * API Validation Pipeline
-	*/
+	 */
 	app.useGlobalPipes(
 		new ValidationPipe({
 			transform: true,
@@ -27,13 +27,13 @@ export const setupNestApplication = (app: INestApplication) => {
 
 	/**
 	 * Server Exception Filter
-	*/
+	 */
 	const discordWebhookService = app.get(DiscordWebhookService);
 	app.useGlobalFilters(new HttpExceptionFilter(discordWebhookService));
-	
+
 	/**
 	 * API Response Format Interceptor
-	*/
+	 */
 	app.useGlobalInterceptors(new ApiResponseInterceptor());
 
 	/**
@@ -50,7 +50,7 @@ export const setupNestApplication = (app: INestApplication) => {
 
 	/**
 	 * Disable non-security Header
-	*/
+	 */
 	const expressApp: Application = app.getHttpAdapter().getInstance();
 	expressApp.disable('x-powered-by');
 	expressApp.disable('Server');

--- a/src/common/configs/setup.config.ts
+++ b/src/common/configs/setup.config.ts
@@ -3,6 +3,7 @@ import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
 
 import * as cookieParser from 'cookie-parser';
 
+import { DiscordWebhookService } from '#/discord/discord.service';
 import { ApiResponseInterceptor } from '#middlewares/api-response.interceptor';
 import { HttpExceptionFilter } from '#middlewares/http-exception.filter';
 
@@ -18,7 +19,10 @@ export const setupNestApplication = (app: INestApplication) => {
 			exceptionFactory: (errors) => new ValidationException(errors),
 		}),
 	);
-	app.useGlobalFilters(new HttpExceptionFilter());
+
+	const discordWebhookService = app.get(DiscordWebhookService);
+	app.useGlobalFilters(new HttpExceptionFilter(discordWebhookService));
+	
 	app.useGlobalInterceptors(new ApiResponseInterceptor());
 
 	const config = new DocumentBuilder()

--- a/src/common/interfaces/api-error-response.interface.ts
+++ b/src/common/interfaces/api-error-response.interface.ts
@@ -1,9 +1,9 @@
-import { HttpStatus } from "@nestjs/common";
+import { HttpStatus } from '@nestjs/common';
 
 export interface ApiErrorResponse {
-    timestamp: string;
-    statusCode: HttpStatus;
-    path: string,
-    method: string,
-    message: string,
+	timestamp: string;
+	statusCode: HttpStatus;
+	path: string;
+	method: string;
+	message: string;
 }

--- a/src/common/interfaces/api-error-response.interface.ts
+++ b/src/common/interfaces/api-error-response.interface.ts
@@ -1,0 +1,9 @@
+import { HttpStatus } from "@nestjs/common";
+
+export interface ApiErrorResponse {
+    timestamp: string;
+    statusCode: HttpStatus;
+    path: string,
+    method: string,
+    message: string,
+}

--- a/src/common/middlewares/http-exception.filter.ts
+++ b/src/common/middlewares/http-exception.filter.ts
@@ -26,6 +26,7 @@ export class HttpExceptionFilter implements ExceptionFilter {
 		const request = ctx.getRequest<Request>();
 
 		let statusCode: HttpStatus = HttpStatus.INTERNAL_SERVER_ERROR;
+		
 		let error: unknown = exception;
 		let errorResponse: Record<string, unknown> = {
 			timestamp: new Date().toISOString(),
@@ -46,12 +47,12 @@ export class HttpExceptionFilter implements ExceptionFilter {
 				);
 
 				statusCode = HttpStatus.BAD_REQUEST;
-				(error = errorDetails),
-					(errorResponse = {
-						...errorResponse,
-						statusCode,
-						message: exception.message,
-					});
+				error = errorDetails;
+				errorResponse = {
+					...errorResponse,
+					statusCode,
+					message: exception.message,
+				};
 				break;
 			}
 			case exception instanceof HttpException: {
@@ -61,12 +62,12 @@ export class HttpExceptionFilter implements ExceptionFilter {
 				>;
 
 				statusCode = exception.getStatus();
-				(error = responseBody.error),
-					(errorResponse = {
-						...errorResponse,
-						statusCode,
-						message: responseBody.message,
-					});
+				error = responseBody.error;
+				errorResponse = {
+					...errorResponse,
+					statusCode,
+					message: responseBody.message,
+				};
 				break;
 			}
 			default: {

--- a/src/common/middlewares/logger.middleware.ts
+++ b/src/common/middlewares/logger.middleware.ts
@@ -16,8 +16,6 @@ export class LoggerMiddleware implements NestMiddleware {
 		const { method, originalUrl, query, body } = request;
 		const { statusCode } = response;
 
-
-
 		this.logger.log({
 			message: 'HTTP Request',
 			statusCode,

--- a/src/discord/discord.module.ts
+++ b/src/discord/discord.module.ts
@@ -1,7 +1,7 @@
 import { Module } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
-import { DiscordWebhookService } from './discord.service';
 
+import { DiscordWebhookService } from './discord.service';
 
 @Module({
 	imports: [ConfigModule],

--- a/src/discord/discord.module.ts
+++ b/src/discord/discord.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { ConfigModule } from '@nestjs/config';
+import { DiscordWebhookService } from './discord.service';
+
+
+@Module({
+	imports: [ConfigModule],
+	providers: [DiscordWebhookService],
+	exports: [DiscordWebhookService],
+})
+export class DiscordWebhookModule {}

--- a/src/discord/discord.service.ts
+++ b/src/discord/discord.service.ts
@@ -1,5 +1,6 @@
 import { Injectable, InternalServerErrorException } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
+import * as dayjs from 'dayjs';
 
 import { postAsync } from '#/common/apis';
 import { ApiErrorResponse } from '#/common/interfaces/api-error-response.interface';
@@ -34,37 +35,42 @@ export class DiscordWebhookService {
 		return this.sendDiscordMessage(embedMessage);
 	}
 
-	private async sendDiscordMessage(payload: Embed) {
-		return postAsync(this.discordWebhookUrl, payload);
+	private async sendDiscordMessage(embedMessage: Embed[]) {
+		return postAsync(this.discordWebhookUrl, { embeds: embedMessage });
 	}
 
 	private createEmbedErrorMessage(
 		errorResponse: ApiErrorResponse,
 		errorStack: string[] | string,
-	): Embed {
+	) {
 		const { timestamp, statusCode, path, method, message } = errorResponse;
+		const errorOccurredTime = dayjs(timestamp).format('YYYY년 MM월 DD일 HH시 mm분 ss초');
 		const errorStackMessage = Array.isArray(errorStack)
-			? errorStack.join('\n')
+			? errorStack.join("\n")
 			: errorStack;
 
-		const embedMessage: Embed = {
-			title: `데브말ㅆㆍ미 서버에서 ${statusCode} 에러가 발생했습니다.`,
-			description: message,
-			fields: [
-				{
-					name: '⏰ 에러 발생 시각',
-					value: timestamp,
-				},
-				{
-					name: '🔗 URL / HTTP Method',
-					value: `${method.toUpperCase()} ${path}`,
-				},
-				{
-					name: '📂 Error Stack',
-					value: errorStackMessage,
-				},
-			],
-		};
+		const embedMessage: Embed[] = [
+			{
+				title: `데브말ㅆㆍ미 서버에서 ${statusCode} 에러가 발생했습니다.`,
+				description: message,
+				color: 15548997, // NOTE: RED
+				fields: [
+					{
+						name: '⏰ 에러 발생 시각',
+						value: errorOccurredTime,
+					},
+					{
+						name: '🔗 URL / HTTP Method',
+						value: `${method.toUpperCase()} ${path}`,
+					},
+					{
+						name: '📂 Error Stack',
+						value: `\`\`\`${errorStackMessage}\`\`\``,
+						inline: true,
+					},
+				],
+			},
+		];
 
 		return embedMessage;
 	}

--- a/src/discord/discord.service.ts
+++ b/src/discord/discord.service.ts
@@ -1,0 +1,30 @@
+import { Injectable, InternalServerErrorException } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+
+import { postAsync } from '#/common/apis';
+
+import Embed from './interface/embed-message.interface';
+
+@Injectable()
+export class DiscordWebhookService {
+	private readonly discordWebhookUrl: string;
+
+	constructor(private readonly configService: ConfigService) {
+		const discordWebHookUrl = this.configService.get<string>(
+			'DISCORD_WEBHOOK_URL',
+		);
+
+		if (!discordWebHookUrl)
+			throw new InternalServerErrorException(
+				'DISCORD_WEBHOOK_URL 환경 변수가 존재하지 않습니다.',
+			);
+
+		this.discordWebhookUrl = discordWebHookUrl;
+	}
+
+	public sendDiscordMessage(payload: Embed) {
+		return postAsync(this.discordWebhookUrl, payload);
+	}
+
+	public async createEmbedErrorMessage() {}
+}

--- a/src/discord/discord.service.ts
+++ b/src/discord/discord.service.ts
@@ -1,5 +1,6 @@
 import { Injectable, InternalServerErrorException } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
+
 import * as dayjs from 'dayjs';
 
 import { postAsync } from '#/common/apis';
@@ -44,9 +45,11 @@ export class DiscordWebhookService {
 		errorStack: string[] | string,
 	) {
 		const { timestamp, statusCode, path, method, message } = errorResponse;
-		const errorOccurredTime = dayjs(timestamp).format('YYYY년 MM월 DD일 HH시 mm분 ss초');
+		const errorOccurredTime = dayjs(timestamp).format(
+			'YYYY년 MM월 DD일 HH시 mm분 ss초',
+		);
 		const errorStackMessage = Array.isArray(errorStack)
-			? errorStack.join("\n")
+			? errorStack.join('\n')
 			: errorStack;
 
 		const embedMessage: Embed[] = [

--- a/src/discord/discord.service.ts
+++ b/src/discord/discord.service.ts
@@ -2,6 +2,7 @@ import { Injectable, InternalServerErrorException } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 
 import { postAsync } from '#/common/apis';
+import { ApiErrorResponse } from '#/common/interfaces/api-error-response.interface';
 
 import Embed from './interface/embed-message.interface';
 
@@ -22,9 +23,49 @@ export class DiscordWebhookService {
 		this.discordWebhookUrl = discordWebHookUrl;
 	}
 
-	public sendDiscordMessage(payload: Embed) {
+	public sendExceptionMessage(
+		exception: ApiErrorResponse,
+		errorStack: string[] | string,
+	) {
+		const embedMessage = this.createEmbedErrorMessage(
+			exception,
+			errorStack,
+		);
+		return this.sendDiscordMessage(embedMessage);
+	}
+
+	private async sendDiscordMessage(payload: Embed) {
 		return postAsync(this.discordWebhookUrl, payload);
 	}
 
-	public async createEmbedErrorMessage() {}
+	private createEmbedErrorMessage(
+		errorResponse: ApiErrorResponse,
+		errorStack: string[] | string,
+	): Embed {
+		const { timestamp, statusCode, path, method, message } = errorResponse;
+		const errorStackMessage = Array.isArray(errorStack)
+			? errorStack.join('\n')
+			: errorStack;
+
+		const embedMessage: Embed = {
+			title: `데브말ㅆㆍ미 서버에서 ${statusCode} 에러가 발생했습니다.`,
+			description: message,
+			fields: [
+				{
+					name: '⏰ 에러 발생 시각',
+					value: timestamp,
+				},
+				{
+					name: '🔗 URL / HTTP Method',
+					value: `${method.toUpperCase()} ${path}`,
+				},
+				{
+					name: '📂 Error Stack',
+					value: errorStackMessage,
+				},
+			],
+		};
+
+		return embedMessage;
+	}
 }

--- a/src/discord/interface/attachment.interface.ts
+++ b/src/discord/interface/attachment.interface.ts
@@ -1,0 +1,38 @@
+export default interface Attachment {
+
+    /**
+     * Attachment ID.
+     */
+    id: string;
+
+    /**
+     * Name of the file attached.
+     */
+    filename: string;
+
+    /**
+     * Size of the file in bytes.
+     */
+    size: number;
+
+    /**
+     * Source URL of the file.
+     */
+    url: string;
+
+    /**
+     * A proxied URL of the file.
+     */
+    proxy_url: string;
+
+    /**
+     * Height of the file. (if image)
+     */
+    height?: number;
+
+    /**
+     * Width of the file. (if image)
+     */
+    width: number;
+
+}

--- a/src/discord/interface/attachment.interface.ts
+++ b/src/discord/interface/attachment.interface.ts
@@ -1,38 +1,36 @@
 export default interface Attachment {
+	/**
+	 * Attachment ID.
+	 */
+	id: string;
 
-    /**
-     * Attachment ID.
-     */
-    id: string;
+	/**
+	 * Name of the file attached.
+	 */
+	filename: string;
 
-    /**
-     * Name of the file attached.
-     */
-    filename: string;
+	/**
+	 * Size of the file in bytes.
+	 */
+	size: number;
 
-    /**
-     * Size of the file in bytes.
-     */
-    size: number;
+	/**
+	 * Source URL of the file.
+	 */
+	url: string;
 
-    /**
-     * Source URL of the file.
-     */
-    url: string;
+	/**
+	 * A proxied URL of the file.
+	 */
+	proxy_url: string;
 
-    /**
-     * A proxied URL of the file.
-     */
-    proxy_url: string;
+	/**
+	 * Height of the file. (if image)
+	 */
+	height?: number;
 
-    /**
-     * Height of the file. (if image)
-     */
-    height?: number;
-
-    /**
-     * Width of the file. (if image)
-     */
-    width: number;
-
+	/**
+	 * Width of the file. (if image)
+	 */
+	width: number;
 }

--- a/src/discord/interface/embed-message.interface.ts
+++ b/src/discord/interface/embed-message.interface.ts
@@ -1,4 +1,4 @@
-import Attachment from "./attachment.interface";
+import Attachment from './attachment.interface';
 
 /**
  * Embed object.
@@ -6,99 +6,97 @@ import Attachment from "./attachment.interface";
  * @link https://discordapp.com/developers/docs/resources/channel#embed-object
  */
 export default interface Embed {
-    /**
-     * Title of the embed.
-     * Up to 256 characters.
-     */
-    title?: string;
+	/**
+	 * Title of the embed.
+	 * Up to 256 characters.
+	 */
+	title?: string;
 
-    /**
-     * Embed type.
-     * (Always "rich" for webhook embeds)
-     */
-    type?: 'rich';
+	/**
+	 * Embed type.
+	 * (Always "rich" for webhook embeds)
+	 */
+	type?: 'rich';
 
-    /**
-     * URL of embed.
-     */
-    url?: string;
+	/**
+	 * URL of embed.
+	 */
+	url?: string;
 
-    /**
-     * Description of the embed.
-     * Up to 2048 characters.
-     */
-    description?: string;
+	/**
+	 * Description of the embed.
+	 * Up to 2048 characters.
+	 */
+	description?: string;
 
-    /**
-     * ISO8601 timestamp of the embed content.
-     */
-    timestamp?: string;
+	/**
+	 * ISO8601 timestamp of the embed content.
+	 */
+	timestamp?: string;
 
-    /**
-     * color code of the embed.
-     */
-    color?: number;
+	/**
+	 * color code of the embed.
+	 */
+	color?: number;
 
-    /**
-     * Footer information.
-     */
-    footer?: EmbedFooter;
+	/**
+	 * Footer information.
+	 */
+	footer?: EmbedFooter;
 
-    /**
-     * Image information.
-     */
-    image?: EmbedImage;
+	/**
+	 * Image information.
+	 */
+	image?: EmbedImage;
 
-    /**
-     * Thumbnail information.
-     */
-    thumbnail?: EmbedThumbnail;
+	/**
+	 * Thumbnail information.
+	 */
+	thumbnail?: EmbedThumbnail;
 
-    /**
-     * Video information.
-     */
-    video?: EmbedVideo;
+	/**
+	 * Video information.
+	 */
+	video?: EmbedVideo;
 
-    /**
-     * Provider information.
-     */
-    provider?: EmbedProvider;
+	/**
+	 * Provider information.
+	 */
+	provider?: EmbedProvider;
 
-    /**
-     * Author information.
-     */
-    author?: EmbedAuthor;
+	/**
+	 * Author information.
+	 */
+	author?: EmbedAuthor;
 
-    /**
-     * Fields information.
-     * Up to 25 fields.
-     */
-    fields?: EmbedField[];
+	/**
+	 * Fields information.
+	 * Up to 25 fields.
+	 */
+	fields?: EmbedField[];
 }
 
 interface EmbedAuthor {
+	/**
+	 * Name of the author.
+	 */
+	name?: string;
 
-    /**
-     * Name of the author.
-     */
-    name?: string;
+	/**
+	 * URL of the author.
+	 */
+	url?: string;
 
-    /**
-     * URL of the author.
-     */
-    url?: string;
+	/**
+	 * URL of the author icon.
+	 * (Only supports HTTP(s) and attachments)
+	 */
+	icon_url?: string | Attachment;
 
-    /**
-     * URL of the author icon.
-     * (Only supports HTTP(s) and attachments)
-     */
-    icon_url?: string | Attachment;
-
-    /**
-     * Proxied URL of the author icon.
-     */
-    proxy_icon_url?: string;
-
+	/**
+	 * Proxied URL of the author icon.
+	 */
+	proxy_icon_url?: string;
 }
 
 /**
@@ -107,24 +105,22 @@ interface EmbedAuthor {
  * @link https://discordapp.com/developers/docs/resources/channel#embed-object-embed-field-structure
  */
 interface EmbedField {
+	/**
+	 * Name of the field.
+	 * Up to 256 characters.
+	 */
+	name: string;
 
-    /**
-     * Name of the field.
-     * Up to 256 characters.
-     */
-    name: string;
+	/**
+	 * Value of the field.
+	 * Up to 1024 characters.
+	 */
+	value: string;
 
-    /**
-     * Value of the field.
-     * Up to 1024 characters.
-     */
-    value: string;
-
-    /**
-     * Whether or not this field should be displayed inline.
-     */
-    inline?: boolean;
-
+	/**
+	 * Whether or not this field should be displayed inline.
+	 */
+	inline?: boolean;
 }
 
 /**
@@ -134,23 +130,21 @@ interface EmbedField {
  */
 
 interface EmbedFooter {
+	/**
+	 * Footer text.
+	 */
+	text: string;
 
-    /**
-     * Footer text.
-     */
-    text: string;
+	/**
+	 * URL of the footer icon.
+	 * Only supports HTTP(s) and attachments
+	 */
+	icon_url?: string | Attachment;
 
-    /**
-     * URL of the footer icon.
-     * Only supports HTTP(s) and attachments
-     */
-    icon_url?: string | Attachment;
-
-    /**
-     * A proxied URL of the footer icon.
-     */
-    proxy_icon_url?: string;
-
+	/**
+	 * A proxied URL of the footer icon.
+	 */
+	proxy_icon_url?: string;
 }
 
 /**
@@ -159,26 +153,26 @@ interface EmbedFooter {
  * @link https://discordapp.com/developers/docs/resources/channel#embed-object-embed-image-structure
  */
 interface EmbedImage {
-    /**
-     * Source URL of the image.
-     * (Only supports http(s) and attachments)
-     */
-    url: string | Attachment;
+	/**
+	 * Source URL of the image.
+	 * (Only supports http(s) and attachments)
+	 */
+	url: string | Attachment;
 
-    /**
-     * A proxied URL of the thumbnail.
-     */
-    proxy_url?: string;
+	/**
+	 * A proxied URL of the thumbnail.
+	 */
+	proxy_url?: string;
 
-    /**
-     * Height of the thumbnail.
-     */
-    height?: number;
+	/**
+	 * Height of the thumbnail.
+	 */
+	height?: number;
 
-    /**
-     * Width of the thumbnail.
-     */
-    width?: number;
+	/**
+	 * Width of the thumbnail.
+	 */
+	width?: number;
 }
 
 /**
@@ -187,17 +181,15 @@ interface EmbedImage {
  * @link https://discordapp.com/developers/docs/resources/channel#embed-object-embed-provider-structure
  */
 interface EmbedProvider {
+	/**
+	 * Name of the provider.
+	 */
+	name?: string;
 
-    /**
-     * Name of the provider.
-     */
-    name?: string;
-
-    /**
-     * URL of the provider.
-     */
-    url?: string;
-
+	/**
+	 * URL of the provider.
+	 */
+	url?: string;
 }
 
 /**
@@ -206,26 +198,26 @@ interface EmbedProvider {
  * @link https://discordapp.com/developers/docs/resources/channel#embed-object-embed-thumbnail-structure
  */
 interface EmbedThumbnail {
-    /**
-     * Source URL of the thumbnail.
-     * (Only supports http(s) and attachments)
-     */
-    url: string | Attachment;
+	/**
+	 * Source URL of the thumbnail.
+	 * (Only supports http(s) and attachments)
+	 */
+	url: string | Attachment;
 
-    /**
-     * A proxied URL of the thumbnail.
-     */
-    proxy_url?: string;
+	/**
+	 * A proxied URL of the thumbnail.
+	 */
+	proxy_url?: string;
 
-    /**
-     * Height of the thumbnail.
-     */
-    height?: number;
+	/**
+	 * Height of the thumbnail.
+	 */
+	height?: number;
 
-    /**
-     * Width of the thumbnail.
-     */
-    width?: number;
+	/**
+	 * Width of the thumbnail.
+	 */
+	width?: number;
 }
 
 /**
@@ -234,18 +226,18 @@ interface EmbedThumbnail {
  * @link https://discordapp.com/developers/docs/resources/channel#embed-object-embed-video-structure
  */
 interface EmbedVideo {
-    /**
-     * Source URL of the video.
-     */
-    url: string;
+	/**
+	 * Source URL of the video.
+	 */
+	url: string;
 
-    /**
-     * Height of the video.
-     */
-    height?: number;
+	/**
+	 * Height of the video.
+	 */
+	height?: number;
 
-    /**
-     * Width of the video.
-     */
-    width?: number;
+	/**
+	 * Width of the video.
+	 */
+	width?: number;
 }

--- a/src/discord/interface/embed-message.interface.ts
+++ b/src/discord/interface/embed-message.interface.ts
@@ -1,0 +1,251 @@
+import Attachment from "./attachment.interface";
+
+/**
+ * Embed object.
+ *
+ * @link https://discordapp.com/developers/docs/resources/channel#embed-object
+ */
+export default interface Embed {
+    /**
+     * Title of the embed.
+     * Up to 256 characters.
+     */
+    title?: string;
+
+    /**
+     * Embed type.
+     * (Always "rich" for webhook embeds)
+     */
+    type?: 'rich';
+
+    /**
+     * URL of embed.
+     */
+    url?: string;
+
+    /**
+     * Description of the embed.
+     * Up to 2048 characters.
+     */
+    description?: string;
+
+    /**
+     * ISO8601 timestamp of the embed content.
+     */
+    timestamp?: string;
+
+    /**
+     * color code of the embed.
+     */
+    color?: number;
+
+    /**
+     * Footer information.
+     */
+    footer?: EmbedFooter;
+
+    /**
+     * Image information.
+     */
+    image?: EmbedImage;
+
+    /**
+     * Thumbnail information.
+     */
+    thumbnail?: EmbedThumbnail;
+
+    /**
+     * Video information.
+     */
+    video?: EmbedVideo;
+
+    /**
+     * Provider information.
+     */
+    provider?: EmbedProvider;
+
+    /**
+     * Author information.
+     */
+    author?: EmbedAuthor;
+
+    /**
+     * Fields information.
+     * Up to 25 fields.
+     */
+    fields?: EmbedField[];
+}
+
+interface EmbedAuthor {
+
+    /**
+     * Name of the author.
+     */
+    name?: string;
+
+    /**
+     * URL of the author.
+     */
+    url?: string;
+
+    /**
+     * URL of the author icon.
+     * (Only supports HTTP(s) and attachments)
+     */
+    icon_url?: string | Attachment;
+
+    /**
+     * Proxied URL of the author icon.
+     */
+    proxy_icon_url?: string;
+
+}
+
+/**
+ * Embed Field Structure
+ *
+ * @link https://discordapp.com/developers/docs/resources/channel#embed-object-embed-field-structure
+ */
+interface EmbedField {
+
+    /**
+     * Name of the field.
+     * Up to 256 characters.
+     */
+    name: string;
+
+    /**
+     * Value of the field.
+     * Up to 1024 characters.
+     */
+    value: string;
+
+    /**
+     * Whether or not this field should be displayed inline.
+     */
+    inline?: boolean;
+
+}
+
+/**
+ * Embed Footer Structure
+ *
+ * @link https://discordapp.com/developers/docs/resources/channel#embed-object-embed-footer-structure
+ */
+
+interface EmbedFooter {
+
+    /**
+     * Footer text.
+     */
+    text: string;
+
+    /**
+     * URL of the footer icon.
+     * Only supports HTTP(s) and attachments
+     */
+    icon_url?: string | Attachment;
+
+    /**
+     * A proxied URL of the footer icon.
+     */
+    proxy_icon_url?: string;
+
+}
+
+/**
+ * Embed Image Structure
+ *
+ * @link https://discordapp.com/developers/docs/resources/channel#embed-object-embed-image-structure
+ */
+interface EmbedImage {
+    /**
+     * Source URL of the image.
+     * (Only supports http(s) and attachments)
+     */
+    url: string | Attachment;
+
+    /**
+     * A proxied URL of the thumbnail.
+     */
+    proxy_url?: string;
+
+    /**
+     * Height of the thumbnail.
+     */
+    height?: number;
+
+    /**
+     * Width of the thumbnail.
+     */
+    width?: number;
+}
+
+/**
+ * Embed Provider Structure
+ *
+ * @link https://discordapp.com/developers/docs/resources/channel#embed-object-embed-provider-structure
+ */
+interface EmbedProvider {
+
+    /**
+     * Name of the provider.
+     */
+    name?: string;
+
+    /**
+     * URL of the provider.
+     */
+    url?: string;
+
+}
+
+/**
+ * Embed Thumbnail Structure
+ *
+ * @link https://discordapp.com/developers/docs/resources/channel#embed-object-embed-thumbnail-structure
+ */
+interface EmbedThumbnail {
+    /**
+     * Source URL of the thumbnail.
+     * (Only supports http(s) and attachments)
+     */
+    url: string | Attachment;
+
+    /**
+     * A proxied URL of the thumbnail.
+     */
+    proxy_url?: string;
+
+    /**
+     * Height of the thumbnail.
+     */
+    height?: number;
+
+    /**
+     * Width of the thumbnail.
+     */
+    width?: number;
+}
+
+/**
+ * Embed Video Structure
+ *
+ * @link https://discordapp.com/developers/docs/resources/channel#embed-object-embed-video-structure
+ */
+interface EmbedVideo {
+    /**
+     * Source URL of the video.
+     */
+    url: string;
+
+    /**
+     * Height of the video.
+     */
+    height?: number;
+
+    /**
+     * Width of the video.
+     */
+    width?: number;
+}


### PR DESCRIPTION
## Task Summary ✨
에러 발생 시 Discord Webhook Embed 메세지 전송
Cookie ReIssue 관련 로직을 AuthService 단으로 위임

## Description 📑
- 서버에서 500 에러 발생 시 Discord Webhook 을 통해 Embed 메세지를 전송하도록 수정
- UserInterceptor, AuthenticatedGuard 단에서 제어했던 Cookie ReIssue 로직을 AuthService 로 위임
- accessToken 이 없어도 refreshToken 을 기반으로 토큰을 재발급하도록 로직 수정

## More Information 🛎
- x-powered-by, server header 가 더 이상 노출되지 않도록 수정했습니다 (보안 취약점)
- 아래와 같이 데브말싸미 Discord Channel 에 메세지가 노출됩니다.
![333](https://github.com/Devminjeong-eum/backend/assets/74497253/9290a101-9bb5-4f95-8a88-cf44f23cdb7c)

## Self Checklist ✅
- [x] 코드 리뷰 요청
- [x] PR 제목 컨벤션에 맞는지 확인
- [x] PR Label 설정