### PR TITLE
[DEV-17] 단어 목록 조회 시 정렬 기준 Query 추가

### DIFF
--- a/src/databases/repositories/word.repository.ts
+++ b/src/databases/repositories/word.repository.ts
@@ -23,6 +23,7 @@ import {
 	RequestWordUserLikeDto,
 	ResponseWordUserLikeDto,
 } from '#/word/dto/word-user-like.dto';
+import { WORD_SORTING_TYPE } from '#/word/interface/word-list-sorting.interface';
 import { Word } from '#databases/entities/word.entity';
 
 @Injectable()
@@ -169,33 +170,44 @@ export class WordRepository {
 	}
 
 	async findWithList(requestWordListDto: RequestWordListDto) {
-		const { userId } = requestWordListDto;
+		const { userId, sorting } = requestWordListDto;
+		const [sortOption, ascOrDesc] = WORD_SORTING_TYPE[sorting];
 
 		const queryBuilder = this.wordRepository.createQueryBuilder('word');
 
-		const [words, totalCount] = await Promise.all([
+		queryBuilder
+			.leftJoin('word.likes', 'like')
+			.select([
+				'word.id',
+				'word.name',
+				'word.description',
+				'word.diacritic',
+				'word.pronunciation',
+				'word.wrongPronunciations',
+				'word.exampleSentence',
+				'COUNT(like.id) AS likeCount',
+			]);
+
+		if (userId) {
 			queryBuilder
-				.leftJoinAndSelect(
-					'word.likes',
-					'like',
-					userId ? 'like.userId = :userId' : '',
-					{ userId },
-				)
-				.select([
-					'word.id',
-					'word.name',
-					'word.pronunciation',
-					'word.diacritic',
-					'word.description',
-					'word.createdAt',
-					'CASE WHEN like.id IS NOT NULL THEN true ELSE false END AS isLike',
+				.addSelect([
+					'SUM(CASE WHEN like.userId = :userId THEN 1 ELSE 0 END) > 0 AS isLike',
 				])
-				.orderBy('word.createdAt', 'ASC')
-				.offset(requestWordListDto.getSkip())
-				.limit(requestWordListDto.limit)
-				.getRawMany(),
-			queryBuilder.getCount(),
-		]);
+				.setParameters({ userId });
+		} else {
+			queryBuilder.addSelect(['false AS isLike']);
+		}
+
+		const words = await queryBuilder
+			.groupBy('word.id')
+			.orderBy(sortOption, ascOrDesc)
+			.offset(requestWordListDto.getSkip())
+			.limit(requestWordListDto.limit)
+			.getRawMany();
+
+		const totalCount = await this.wordRepository
+			.createQueryBuilder('word')
+			.getCount();
 
 		const responseWordListDto = plainToInstance(
 			ResponseWordListDto,

--- a/src/discord/discord.service.ts
+++ b/src/discord/discord.service.ts
@@ -11,11 +11,13 @@ import Embed from './interface/embed-message.interface';
 @Injectable()
 export class DiscordWebhookService {
 	private readonly discordWebhookUrl: string;
+	private readonly isDev: boolean;
 
 	constructor(private readonly configService: ConfigService) {
 		const discordWebHookUrl = this.configService.get<string>(
 			'DISCORD_WEBHOOK_URL',
 		);
+		const isDev = this.configService.get<string>('NODE_ENV') === 'development';
 
 		if (!discordWebHookUrl)
 			throw new InternalServerErrorException(
@@ -23,12 +25,14 @@ export class DiscordWebhookService {
 			);
 
 		this.discordWebhookUrl = discordWebHookUrl;
+		this.isDev = isDev;
 	}
 
 	public sendExceptionMessage(
 		exception: ApiErrorResponse,
 		errorStack: string[] | string,
 	) {
+		if (this.isDev) return;
 		const embedMessage = this.createEmbedErrorMessage(
 			exception,
 			errorStack,

--- a/src/discord/discord.service.ts
+++ b/src/discord/discord.service.ts
@@ -17,7 +17,8 @@ export class DiscordWebhookService {
 		const discordWebHookUrl = this.configService.get<string>(
 			'DISCORD_WEBHOOK_URL',
 		);
-		const isDev = this.configService.get<string>('NODE_ENV') === 'development';
+		const isDev =
+			this.configService.get<string>('NODE_ENV') === 'development';
 
 		if (!discordWebHookUrl)
 			throw new InternalServerErrorException(

--- a/src/word/dto/word-list.dto.ts
+++ b/src/word/dto/word-list.dto.ts
@@ -27,7 +27,7 @@ export class RequestWordListDto extends PaginationOptionDto {
 	@IsIn(SORTING_WORD_OPTION)
 	@ApiProperty({
 		type: 'enum',
-		enum: SORTING_WORD_OPTION
+		enum: SORTING_WORD_OPTION,
 	})
 	sorting: SortingWordListOption = 'CREATED';
 }

--- a/src/word/dto/word-list.dto.ts
+++ b/src/word/dto/word-list.dto.ts
@@ -4,6 +4,8 @@ import { Expose, Transform } from 'class-transformer';
 import {
 	IsArray,
 	IsBoolean,
+	IsIn,
+	IsNumber,
 	IsOptional,
 	IsString,
 	IsUUID,
@@ -11,10 +13,23 @@ import {
 
 import { PaginationOptionDto } from '#/common/dto/pagination.dto';
 
+import {
+	SORTING_WORD_OPTION,
+	type SortingWordListOption,
+} from '../interface/word-list-sorting.interface';
+
 export class RequestWordListDto extends PaginationOptionDto {
 	@IsOptional()
 	@IsUUID()
 	userId?: string;
+
+	@IsOptional()
+	@IsIn(SORTING_WORD_OPTION)
+	@ApiProperty({
+		type: 'enum',
+		enum: SORTING_WORD_OPTION
+	})
+	sorting: SortingWordListOption = 'CREATED';
 }
 
 export class ResponseWordListDto {
@@ -53,4 +68,10 @@ export class ResponseWordListDto {
 	@Expose({ name: 'isLike' })
 	@ApiProperty()
 	isLike: boolean;
+
+	@IsNumber()
+	@Transform(({ obj }) => Number(obj.likecount))
+	@Expose({ name: 'likeCount' })
+	@ApiProperty()
+	likeCount: number;
 }

--- a/src/word/interface/word-list-sorting.interface.ts
+++ b/src/word/interface/word-list-sorting.interface.ts
@@ -1,0 +1,10 @@
+export const WORD_SORTING_TYPE = {
+	CREATED: ['word.createdAt', 'ASC'],
+	LIKED: ['likeCount', 'DESC'],
+	ALPHABET: ['word.name', 'ASC'],
+} as const;
+
+export type SortingWordListOption = keyof typeof WORD_SORTING_TYPE;
+export const SORTING_WORD_OPTION = Object.keys(
+	WORD_SORTING_TYPE,
+) as SortingWordListOption[];

--- a/src/word/word.controller.ts
+++ b/src/word/word.controller.ts
@@ -51,13 +51,17 @@ export class WordController {
 	@Get('/list')
 	async findAll(
 		@AuthenticatedUser() user: User,
-		@Query() paginationOptionDto: PaginationOptionDto,
+		@Query() wordListDto: RequestWordListDto,
 	) {
-		const requestWordListDto = plainToInstance(RequestWordListDto, {
-			userId: user?.id,
-			page: paginationOptionDto.page,
-			limit: paginationOptionDto.limit,
-		});
+		const requestWordListDto = plainToInstance(
+			RequestWordListDto,
+			{
+				userId: user?.id,
+				...wordListDto,
+			},
+			{ exposeDefaultValues: true },
+		);
+
 		return await this.wordService.getWordList(requestWordListDto);
 	}
 


### PR DESCRIPTION
## Task Summary ✨
단어 목록 조회 시 정렬 기준 Query 추가

## Description 📑
- 단어 목록을 조회하는 API (`/word/list`) 에 정렬 기준을 정의하는 sorting 옵션을 추가했습니다.
- sorting 의 경우 `CREATED`, `LIKED`, `ALPHABET` 항목을 제공합니다. (생성 순, 좋아요 순, 알파벳 순)
- 단어 목록 API 의 결과 값에 각 단어 별 좋아요 수량 (likeCount) 이 보여지도록 추가했습니다.

![111](https://github.com/Devminjeong-eum/backend/assets/74497253/0c35d09d-b082-4e48-ab0d-62a9196d4fc2)

## More Information 🛎
- 조회순의 경우 아직 관련 기능이 개발되지 않은 상태이기에 현재 PR 에서는 잠시 제외했습니다.
- development 환경에서는 Discord Webhook 이 동작하지 않도록 임시 조치했습니다 (도배 방지)

## Self Checklist ✅
- [x] 코드 리뷰 요청
- [x] PR 제목 컨벤션에 맞는지 확인
- [x] PR Label 설정