### PR TITLE
[DEV-53] 좋아요 단어장 정렬 기능 추가

### DIFF
--- a/src/databases/repositories/word.repository.ts
+++ b/src/databases/repositories/word.repository.ts
@@ -224,7 +224,8 @@ export class WordRepository {
 	}
 
 	async findUserLikeWord(requestWordListDto: RequestWordUserLikeDto) {
-		const { userId } = requestWordListDto;
+		const { userId, sorting } = requestWordListDto;
+		const [sortOption, ascOrDesc] = WORD_SORTING_TYPE[sorting];
 
 		const [words, totalCount] = await this.wordRepository
 			.createQueryBuilder('word')
@@ -239,7 +240,7 @@ export class WordRepository {
 				'word.description',
 				'word.createdAt',
 			])
-			.orderBy('word.createdAt', 'ASC')
+			.orderBy(sortOption, ascOrDesc)
 			.skip(requestWordListDto.getSkip())
 			.take(requestWordListDto.limit)
 			.getManyAndCount();

--- a/src/databases/repositories/word.repository.ts
+++ b/src/databases/repositories/word.repository.ts
@@ -1,28 +1,14 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 
-import { plainToInstance } from 'class-transformer';
 import { DataSource, Repository } from 'typeorm';
 
-import { PaginationDto, PaginationMetaDto } from '#/common/dto/pagination.dto';
 import { RequestCreateWordDto } from '#/word/dto/create-word.dto';
 import { RequestUpdateWordDto } from '#/word/dto/update-word.dto';
-import {
-	RequestWordDetailDto,
-	ResponseWordDetailDto,
-} from '#/word/dto/word-detail.dto';
-import {
-	RequestWordListDto,
-	ResponseWordListDto,
-} from '#/word/dto/word-list.dto';
-import {
-	RequestWordSearchDto,
-	ResponseWordSearchDto,
-} from '#/word/dto/word-search.dto';
-import {
-	RequestWordUserLikeDto,
-	ResponseWordUserLikeDto,
-} from '#/word/dto/word-user-like.dto';
+import { RequestWordDetailDto } from '#/word/dto/word-detail.dto';
+import { RequestWordListDto } from '#/word/dto/word-list.dto';
+import { RequestWordSearchDto } from '#/word/dto/word-search.dto';
+import { RequestWordUserLikeDto } from '#/word/dto/word-user-like.dto';
 import { WORD_SORTING_TYPE } from '#/word/interface/word-list-sorting.interface';
 import { Word } from '#databases/entities/word.entity';
 
@@ -114,14 +100,7 @@ export class WordRepository {
 			queryBuilder.addSelect(['false AS isLike']);
 		}
 
-		const word = await queryBuilder.groupBy('word.id').getRawOne();
-
-		const responseWordDetailDto = plainToInstance(
-			ResponseWordDetailDto,
-			word,
-			{ excludeExtraneousValues: true },
-		);
-		return responseWordDetailDto;
+		return await queryBuilder.groupBy('word.id').getRawOne();
 	}
 
 	async findBySearchWord(requestWordSearchDto: RequestWordSearchDto) {
@@ -155,18 +134,7 @@ export class WordRepository {
 			queryBuilder.getCount(),
 		]);
 
-		const paginationMeta = new PaginationMetaDto({
-			paginationOption: requestWordSearchDto,
-			totalCount,
-		});
-
-		const responseWordSearchDto = plainToInstance(
-			ResponseWordSearchDto,
-			words,
-			{ excludeExtraneousValues: true },
-		);
-
-		return new PaginationDto(responseWordSearchDto, paginationMeta);
+		return { words, totalCount };
 	}
 
 	async findWithList(requestWordListDto: RequestWordListDto) {
@@ -209,18 +177,10 @@ export class WordRepository {
 			.createQueryBuilder('word')
 			.getCount();
 
-		const responseWordListDto = plainToInstance(
-			ResponseWordListDto,
+		return {
 			words,
-			{ excludeExtraneousValues: true },
-		);
-
-		const paginationMeta = new PaginationMetaDto({
-			paginationOption: requestWordListDto,
 			totalCount,
-		});
-
-		return new PaginationDto(responseWordListDto, paginationMeta);
+		};
 	}
 
 	async findUserLikeWord(requestWordListDto: RequestWordUserLikeDto) {
@@ -245,16 +205,9 @@ export class WordRepository {
 			.take(requestWordListDto.limit)
 			.getManyAndCount();
 
-		const paginationMeta = new PaginationMetaDto({
-			paginationOption: requestWordListDto,
-			totalCount,
-		});
-
-		const responseWordListDto = plainToInstance(
-			ResponseWordUserLikeDto,
+		return {
 			words,
-		);
-
-		return new PaginationDto(responseWordListDto, paginationMeta);
+			totalCount,
+		};
 	}
 }

--- a/src/databases/repositories/word.repository.ts
+++ b/src/databases/repositories/word.repository.ts
@@ -201,7 +201,7 @@ export class WordRepository {
 				'word.createdAt',
 				'COUNT(like.id) AS likeCount',
 			])
-			.groupBy('word.id')
+			.groupBy('word.id');
 
 		const [words, totalCount] = await Promise.all([
 			queryBuilder

--- a/src/word/dto/word-user-like.dto.ts
+++ b/src/word/dto/word-user-like.dto.ts
@@ -1,7 +1,7 @@
 import { ApiProperty } from '@nestjs/swagger';
 
-import { Exclude } from 'class-transformer';
-import { IsArray, IsIn, IsOptional, IsString, IsUUID } from 'class-validator';
+import { Exclude, Expose, Transform } from 'class-transformer';
+import { IsArray, IsIn, IsNumber, IsOptional, IsString, IsUUID } from 'class-validator';
 
 import { PaginationOptionDto } from '#/common/dto/pagination.dto';
 
@@ -26,36 +26,40 @@ export class RequestWordUserLikeDto extends PaginationOptionDto {
 
 export class ResponseWordUserLikeDto {
 	@IsUUID()
-	@ApiProperty({
-		type: String,
-	})
+	@Transform(({ obj }) => obj.word_id)
+	@Expose({ name: 'id' })
+	@ApiProperty()
 	id: string;
 
 	@IsString()
-	@ApiProperty({
-		type: String,
-	})
+	@Transform(({ obj }) => obj.word_name)
+	@Expose({ name: 'name' })
+	@ApiProperty()
 	name: string;
 
 	@IsString()
-	@ApiProperty({
-		type: String,
-	})
+	@Transform(({ obj }) => obj.word_description)
+	@Expose({ name: 'description' })
+	@ApiProperty()
 	description: string;
 
 	@IsArray()
-	@ApiProperty({
-		type: String,
-		isArray: true,
-	})
+	@Transform(({ obj }) => obj.word_diacritic)
+	@Expose({ name: 'diacritic' })
+	@ApiProperty()
 	diacritic: string[];
 
 	@IsArray()
-	@ApiProperty({
-		type: String,
-		isArray: true,
-	})
+	@Transform(({ obj }) => obj.word_pronunciation)
+	@Expose({ name: 'pronunciation' })
+	@ApiProperty()
 	pronunciation: string[];
+
+	@IsNumber()
+	@Transform(({ obj }) => Number(obj.likecount))
+	@Expose({ name: 'likeCount' })
+	@ApiProperty()
+	likeCount: number;
 
 	@Exclude()
 	createdAt: Date;

--- a/src/word/dto/word-user-like.dto.ts
+++ b/src/word/dto/word-user-like.dto.ts
@@ -1,13 +1,26 @@
 import { ApiProperty } from '@nestjs/swagger';
 
 import { Exclude } from 'class-transformer';
-import { IsArray, IsString, IsUUID } from 'class-validator';
+import { IsArray, IsIn, IsOptional, IsString, IsUUID } from 'class-validator';
 
 import { PaginationOptionDto } from '#/common/dto/pagination.dto';
+
+import {
+	SORTING_WORD_OPTION,
+	type SortingWordListOption,
+} from '../interface/word-list-sorting.interface';
 
 export class RequestWordUserLikeDto extends PaginationOptionDto {
 	@IsUUID()
 	userId: string;
+
+	@IsOptional()
+	@IsIn(SORTING_WORD_OPTION)
+	@ApiProperty({
+		type: 'enum',
+		enum: SORTING_WORD_OPTION,
+	})
+	sorting: SortingWordListOption = 'CREATED';
 }
 
 export class ResponseWordUserLikeDto {

--- a/src/word/dto/word-user-like.dto.ts
+++ b/src/word/dto/word-user-like.dto.ts
@@ -12,7 +12,8 @@ import {
 
 export class RequestWordUserLikeDto extends PaginationOptionDto {
 	@IsUUID()
-	userId: string;
+	@IsOptional()
+	userId?: string;
 
 	@IsOptional()
 	@IsIn(SORTING_WORD_OPTION)

--- a/src/word/dto/word-user-like.dto.ts
+++ b/src/word/dto/word-user-like.dto.ts
@@ -1,7 +1,14 @@
 import { ApiProperty } from '@nestjs/swagger';
 
 import { Exclude, Expose, Transform } from 'class-transformer';
-import { IsArray, IsIn, IsNumber, IsOptional, IsString, IsUUID } from 'class-validator';
+import {
+	IsArray,
+	IsIn,
+	IsNumber,
+	IsOptional,
+	IsString,
+	IsUUID,
+} from 'class-validator';
 
 import { PaginationOptionDto } from '#/common/dto/pagination.dto';
 

--- a/src/word/word.controller.ts
+++ b/src/word/word.controller.ts
@@ -15,7 +15,6 @@ import { plainToInstance } from 'class-transformer';
 import { AuthenticatedUser } from '#/auth/decorator/auth.decorator';
 import { AuthenticationGuard } from '#/auth/guard/auth.guard';
 import { ApiDocs } from '#/common/decorators/swagger.decorator';
-import { PaginationOptionDto } from '#/common/dto/pagination.dto';
 import { UserInformationInterceptor } from '#/user/interceptors/user-information.interceptor';
 import { User } from '#databases/entities/user.entity';
 
@@ -77,12 +76,11 @@ export class WordController {
 	@Get('/like')
 	async findUserLike(
 		@AuthenticatedUser() user: User,
-		@Query() paginationOptionDto: PaginationOptionDto,
+		@Query() requestWordUserDto: RequestWordUserLikeDto,
 	) {
 		const wordUserLikeDto = plainToInstance(RequestWordUserLikeDto, {
+			...requestWordUserDto,
 			userId: user.id,
-			page: paginationOptionDto.page,
-			limit: paginationOptionDto.limit,
 		});
 		return await this.wordService.getWordUserLike(wordUserLikeDto);
 	}

--- a/src/word/word.service.ts
+++ b/src/word/word.service.ts
@@ -132,6 +132,7 @@ export class WordService {
 		const responseWordUserLikeListDto = plainToInstance(
 			ResponseWordUserLikeDto,
 			words,
+			{ excludeExtraneousValues: true },
 		);
 		const paginationMeta = new PaginationMetaDto({
 			paginationOption: requestWordUserLikeDto,

--- a/src/word/word.service.ts
+++ b/src/word/word.service.ts
@@ -3,15 +3,25 @@ import { Cron, CronExpression } from '@nestjs/schedule';
 
 import { plainToInstance } from 'class-transformer';
 
+import { PaginationDto, PaginationMetaDto } from '#/common/dto/pagination.dto';
 import { SpreadSheetService } from '#/spread-sheet/spread-sheet.service';
 import { WordRepository } from '#databases/repositories/word.repository';
 
 import { RequestCreateWordDto } from './dto/create-word.dto';
 import { RequestUpdateWordDto } from './dto/update-word.dto';
-import { RequestWordDetailDto } from './dto/word-detail.dto';
-import { RequestWordListDto } from './dto/word-list.dto';
-import { RequestWordSearchDto } from './dto/word-search.dto';
-import { RequestWordUserLikeDto } from './dto/word-user-like.dto';
+import {
+	RequestWordDetailDto,
+	ResponseWordDetailDto,
+} from './dto/word-detail.dto';
+import { RequestWordListDto, ResponseWordListDto } from './dto/word-list.dto';
+import {
+	RequestWordSearchDto,
+	ResponseWordSearchDto,
+} from './dto/word-search.dto';
+import {
+	RequestWordUserLikeDto,
+	ResponseWordUserLikeDto,
+} from './dto/word-user-like.dto';
 
 @Injectable()
 export class WordService {
@@ -102,12 +112,33 @@ export class WordService {
 		return await this.updateWordList();
 	}
 
-	async getWordList(wordListDto: RequestWordListDto) {
-		return await this.wordRepository.findWithList(wordListDto);
+	async getWordList(requestWordListDto: RequestWordListDto) {
+		const { words, totalCount } =
+			await this.wordRepository.findWithList(requestWordListDto);
+
+		const responseWordListDto = plainToInstance(ResponseWordListDto, words);
+		const paginationMeta = new PaginationMetaDto({
+			paginationOption: requestWordListDto,
+			totalCount,
+		});
+
+		return new PaginationDto(responseWordListDto, paginationMeta);
 	}
 
-	async getWordUserLike(wordUserLikeDto: RequestWordUserLikeDto) {
-		return await this.wordRepository.findUserLikeWord(wordUserLikeDto);
+	async getWordUserLike(requestWordUserLikeDto: RequestWordUserLikeDto) {
+		const { words, totalCount } =
+			await this.wordRepository.findUserLikeWord(requestWordUserLikeDto);
+
+		const responseWordUserLikeListDto = plainToInstance(
+			ResponseWordUserLikeDto,
+			words,
+		);
+		const paginationMeta = new PaginationMetaDto({
+			paginationOption: requestWordUserLikeDto,
+			totalCount,
+		});
+
+		return new PaginationDto(responseWordUserLikeListDto, paginationMeta);
 	}
 
 	async getWordById(wordDetailDto: RequestWordDetailDto) {
@@ -118,10 +149,31 @@ export class WordService {
 			throw new BadRequestException(
 				`해당 ID 를 가진 Word 가 존재하지 않습니다.`,
 			);
-		return word;
+
+		const responseWordDetailDto = plainToInstance(
+			ResponseWordDetailDto,
+			word,
+			{ excludeExtraneousValues: true },
+		);
+
+		return responseWordDetailDto;
 	}
 
 	async getWordByKeyword(requestWordSearchDto: RequestWordSearchDto) {
-		return await this.wordRepository.findBySearchWord(requestWordSearchDto);
+		const { words, totalCount } =
+			await this.wordRepository.findBySearchWord(requestWordSearchDto);
+
+		const paginationMeta = new PaginationMetaDto({
+			paginationOption: requestWordSearchDto,
+			totalCount,
+		});
+
+		const responseWordSearchDto = plainToInstance(
+			ResponseWordSearchDto,
+			words,
+			{ excludeExtraneousValues: true },
+		);
+
+		return new PaginationDto(responseWordSearchDto, paginationMeta);
 	}
 }


### PR DESCRIPTION
## Task Summary ✨
좋아요 단어장 정렬 기능 추가

## Description 📑
- 유저가 좋아요를 누른 단어 목록에 sorting Query 옵션을 추가했습니다 (CREATED, LIKED, ALPHABET)
- 유저가 좋아요를 누른 단어 목록에 좋아요 수량 (likedCount) field 도 동봉하도록 로직을 추가했습니다.  

## More Information 🛎
- 이제 더 이상 Repository 에서 Response DTO 를 정제하지 않고 Service 로직에서 이를 처리하도록 수정했습니다.

## Self Checklist ✅
- [x] 코드 리뷰 요청
- [x] PR 제목 컨벤션에 맞는지 확인
- [x] PR Label 설정