### PR TITLE
[DEV-60] 퀴즈 결과 생성 내 유효성 검사 추가 및 만료된 데이터 안내

### DIFF
--- a/src/databases/repositories/quizResult.repository.ts
+++ b/src/databases/repositories/quizResult.repository.ts
@@ -35,7 +35,6 @@ export class QuizResultRepository {
 		return await this.quizResultRepository
 			.createQueryBuilder('quizResult')
 			.where('quizResult.id = :quizResultId', { quizResultId })
-			.andWhere('quizResult.expiredAt > :now', { now: new Date() })
 			.getOne();
 	}
 }

--- a/src/databases/repositories/word.repository.ts
+++ b/src/databases/repositories/word.repository.ts
@@ -41,6 +41,18 @@ export class WordRepository {
 		return this.wordRepository.findOneBy({ id: wordId });
 	}
 
+	async checkIsExistsByIdList(wordIdList: string[]) {
+		if (!wordIdList.length) return false;
+
+		const wordCount = await this.wordRepository
+			.createQueryBuilder('word')
+			.where('word.id IN (:...wordIdList)', { wordIdList })
+			.select(['word.id'])
+			.getCount();
+
+		return wordCount === wordIdList.length;
+	}
+
 	async findByIdListWithUserLike({
 		wordIdList,
 		userId,

--- a/src/quiz/quiz.service.ts
+++ b/src/quiz/quiz.service.ts
@@ -150,7 +150,13 @@ export class QuizService {
 			);
 		}
 
-		const { id, correctWordIds, incorrectWordIds } = quizResult;
+		if (quizResult.expiredAt <= new Date()) {
+			throw new BadRequestException(
+				'해당 ID 를 가진 퀴즈 결과 데이터는 만료되어 접근할 수 없습니다.',
+			);
+		}
+
+		const { correctWordIds, incorrectWordIds } = quizResult;
 		const [correctWords, incorrectWords] = await Promise.all([
 			this.wordRepository.findByIdListWithUserLike({
 				wordIdList: correctWordIds,
@@ -162,12 +168,20 @@ export class QuizService {
 			}),
 		]);
 
-		const score = correctWordIds.length * 10;
+		const correctWordAmount = correctWords.length;
+		const incorrectWordAmount = incorrectWords.length;
 
+		if (correctWordAmount + incorrectWordAmount !== 10) {
+			throw new InternalServerErrorException(
+				'유효하지 않은 않은 퀴즈 결과 데이터입니다. 관리자에게 문의하세요.',
+			);
+		}
+
+		const score = correctWordAmount * 10;
 		const responseQuizResultDto = plainToInstance(
 			ResponseQuizResultDto,
 			{
-				quizResultId: id,
+				quizResultId,
 				score,
 				correctWords,
 				incorrectWords,

--- a/src/quiz/quiz.service.ts
+++ b/src/quiz/quiz.service.ts
@@ -2,6 +2,7 @@ import {
 	BadRequestException,
 	Injectable,
 	InternalServerErrorException,
+	NotFoundException
 } from '@nestjs/common';
 import { Cron, CronExpression } from '@nestjs/schedule';
 
@@ -127,6 +128,15 @@ export class QuizService {
 			);
 		}
 
+		const [isValidCorrectWords, isValidIncorrectWords] = await Promise.all([
+			this.wordRepository.checkIsExistsByIdList(correctWordIds),
+			this.wordRepository.checkIsExistsByIdList(incorrectWordIds)
+		])
+
+		if (!isValidCorrectWords || !isValidIncorrectWords) {
+			throw new BadRequestException('단어 목록 중에 유효하지 않은 ID 가 있습니다.')
+		}
+
 		const createdQuizResult =
 			await this.quizResultRepository.create(createQuizResultDto);
 
@@ -151,7 +161,7 @@ export class QuizService {
 		}
 
 		if (quizResult.expiredAt <= new Date()) {
-			throw new BadRequestException(
+			throw new NotFoundException(
 				'해당 ID 를 가진 퀴즈 결과 데이터는 만료되어 접근할 수 없습니다.',
 			);
 		}


### PR DESCRIPTION
## Task Summary ✨
- 유효하지 않은 퀴즈 데이터와 만료된 경우를 구분짓도록 수정

## Description 📑
- 퀴즈 데이터가 유효하지 않은 경우 (Word 의 합이 10개 미만인 경우) 에 대해서 500 에러를 던지도록 수정
- 퀴즈 데이터의 `expiredAt` 이 현재 시간보다 이전일 경우 만료된 데이터를 알리고 404 에러를 던지도록 수정
- 퀴즈 결과 생성 시 유효하지 않은 WordId 가 들어갈 경우 이를 검증하여 400 에러를 던지도록 수정

## Self Checklist ✅
- [x] 코드 리뷰 요청
- [x] PR 제목 컨벤션에 맞는지 확인
- [x] PR Label 설정