### PR TITLE
[DEV-59] 유저 정보 조회 API 에 누른 좋아요 수량 추가

### DIFF
--- a/src/databases/repositories/user.repository.ts
+++ b/src/databases/repositories/user.repository.ts
@@ -18,32 +18,41 @@ export class UserRepository {
 		return await this.userRepository.save(registeredUser);
 	}
 
-	findById(id: string) {
-		return this.userRepository.findOne({
-			where: {
-				id,
-			},
-			select: {
-				id: true,
-				profileImage: true,
-				name: true,
-				socialType: true,
-			},
-		});
+	checkIsExistsById(userId: string) {
+		return this.userRepository
+			.createQueryBuilder('user')
+			.where('user.id = :userId', { userId })
+			.getExists();
+	}
+
+	findById(userId: string) {
+		return this.userRepository
+			.createQueryBuilder('user')
+			.leftJoin('user.likes', 'like')
+			.where('user.id = :userId', { userId })
+			.select([
+				'user.id',
+				'user.profileImage',
+				'user.name',
+				'COUNT(like.id) as likeCount',
+			])
+			.groupBy('user.id')
+			.getRawOne();
 	}
 
 	findByName(name: string) {
-		return this.userRepository.findOne({
-			where: {
-				name,
-			},
-			select: {
-				id: true,
-				profileImage: true,
-				name: true,
-				socialType: true,
-			},
-		});
+		return this.userRepository
+			.createQueryBuilder('user')
+			.leftJoin('user.likes', 'like')
+			.where('user.name = :name', { name })
+			.select([
+				'user.id',
+				'user.profileImage',
+				'user.name',
+				'COUNT(like.id) as likeCount',
+			])
+			.groupBy('user.id')
+			.getRawOne();
 	}
 
 	updateName(id: string, name: string) {

--- a/src/user/dto/user-information.dto.ts
+++ b/src/user/dto/user-information.dto.ts
@@ -1,21 +1,30 @@
 import { ApiProperty } from '@nestjs/swagger';
 
-export class ResponseUserInformationDto {
-	@ApiProperty()
-	id: string;
+import { Expose, Transform } from 'class-transformer';
+import { IsNumber, IsString, IsUUID } from 'class-validator';
 
+export class ResponseUserInformationDto {
+	@IsUUID()
+	@Transform(({ obj }) => obj.user_id)
+	@Expose()
+	@ApiProperty()
+	userId: string;
+
+	@IsString()
+	@Transform(({ obj }) => obj.user_name)
+	@Expose()
 	@ApiProperty()
 	name: string;
 
+	@IsString()
+	@Transform(({ obj }) => obj.user_profileImage)
+	@Expose()
 	@ApiProperty()
 	profileImage: string;
 
+	@IsNumber()
+	@Transform(({ obj }) => Number(obj.likecount))
+	@Expose()
 	@ApiProperty()
-	socialType: string;
-
-	@ApiProperty()
-	createdAt: Date;
-
-	@ApiProperty()
-	updatedAt: Date;
+	likeCount: number;
 }

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -1,9 +1,12 @@
 import { BadRequestException, Injectable } from '@nestjs/common';
 
+import { plainToInstance } from 'class-transformer';
+
 import { UserRepository } from '#databases/repositories/user.repository';
 
 import { RequestChangeNicknameDto } from './dto/change-nickname.dto';
 import { RequestCreateUserDto } from './dto/create-user.dto';
+import { ResponseUserInformationDto } from './dto/user-information.dto';
 
 @Injectable()
 export class UserService {
@@ -25,14 +28,21 @@ export class UserService {
 		if (!userInformation) {
 			throw new BadRequestException('존재하지 않는 유저입니다');
 		}
-		return userInformation;
+
+		const responseUserInformationDto = plainToInstance(
+			ResponseUserInformationDto,
+			userInformation,
+			{ excludeExtraneousValues: true },
+		);
+
+		return responseUserInformationDto;
 	}
 
 	async changeUserNickname(changeNickNameDto: RequestChangeNicknameDto) {
 		const { userId, nickname } = changeNickNameDto;
-		const userInformation = await this.userRepository.findById(userId);
+		const isExists = await this.userRepository.checkIsExistsById(userId);
 
-		if (!userInformation) {
+		if (!isExists) {
 			throw new BadRequestException('존재하지 않는 유저입니다');
 		}
 


### PR DESCRIPTION
## Task Summary ✨
유저 정보 조회 API 에 누른 좋아요 수량 추가

## Description 📑
- 유저 정보 조회 API 에 누른 좋아요 수량을 알 수 있는 `likeCount` field 를 추가했습니다.
- 해당 유저가 존재하는지를 판별하는 로직을 `getExists` 메서드를 사용하여 판별하도록 수정했습니다.
- 유저 정보 조회 API 의 Response DTO 에 Transform 및 Validation 로직을 추가했습니다.

## Self Checklist ✅
- [x] 코드 리뷰 요청
- [x] PR 제목 컨벤션에 맞는지 확인
- [x] PR Label 설정