### PR TITLE
[DEV-61] 단어 검색 실시간 목록 제공 API 추가

### DIFF
--- a/src/common/configs/typeorm.configs.ts
+++ b/src/common/configs/typeorm.configs.ts
@@ -23,11 +23,9 @@ export class TypeOrmConfig implements TypeOrmOptionsFactory {
 			retryAttempts: this.isDev ? 0 : 3,
 			retryDelay: 3000,
 			// TODO : 인증서를 적용하여 SSL 연결이 가능하도록 수정 필요
-			...(!this.isDev && {
-				ssl: {
-					rejectUnauthorized: false,
-				},
-			}),
+			ssl: {
+				rejectUnauthorized: false,
+			},
 		};
 	}
 }

--- a/src/databases/repositories/word.repository.ts
+++ b/src/databases/repositories/word.repository.ts
@@ -117,6 +117,15 @@ export class WordRepository {
 		return await queryBuilder.groupBy('word.id').getRawOne();
 	}
 
+	findByRelatedSearchWord(keyword: string) {
+		return this.wordRepository
+			.createQueryBuilder('word')
+			.where('word.name like :keyword', { keyword: `${keyword}%` })
+			.select(['word.id', 'word.name', 'word.diacritic'])
+			.limit(10)
+			.getMany();
+	}
+
 	async findBySearchWord(requestWordSearchDto: RequestWordSearchDto) {
 		const { keyword, userId } = requestWordSearchDto;
 

--- a/src/databases/repositories/word.repository.ts
+++ b/src/databases/repositories/word.repository.ts
@@ -7,6 +7,7 @@ import { RequestCreateWordDto } from '#/word/dto/create-word.dto';
 import { RequestUpdateWordDto } from '#/word/dto/update-word.dto';
 import { RequestWordDetailDto } from '#/word/dto/word-detail.dto';
 import { RequestWordListDto } from '#/word/dto/word-list.dto';
+import { RequestWordRelatedSearchDto } from '#/word/dto/word-related-search.dto';
 import { RequestWordSearchDto } from '#/word/dto/word-search.dto';
 import { RequestWordUserLikeDto } from '#/word/dto/word-user-like.dto';
 import { WORD_SORTING_TYPE } from '#/word/interface/word-list-sorting.interface';
@@ -117,13 +118,22 @@ export class WordRepository {
 		return await queryBuilder.groupBy('word.id').getRawOne();
 	}
 
-	findByRelatedSearchWord(keyword: string) {
-		return this.wordRepository
+	async findByRelatedSearchWord(
+		requestWordRelatedSearchDto: RequestWordRelatedSearchDto,
+	) {
+		const { keyword } = requestWordRelatedSearchDto;
+
+		const [words, totalCount] = await this.wordRepository
 			.createQueryBuilder('word')
 			.where('word.name like :keyword', { keyword: `${keyword}%` })
 			.select(['word.id', 'word.name', 'word.diacritic'])
-			.limit(10)
-			.getMany();
+			.skip(requestWordRelatedSearchDto.getSkip())
+			.take(requestWordRelatedSearchDto.limit)
+			.getManyAndCount();
+
+		console.log(words);
+
+		return { words, totalCount };
 	}
 
 	async findBySearchWord(requestWordSearchDto: RequestWordSearchDto) {

--- a/src/word/dto/word-related-search.dto.ts
+++ b/src/word/dto/word-related-search.dto.ts
@@ -1,0 +1,28 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+import { Expose, Transform } from 'class-transformer';
+import { IsAlpha, IsString, IsUUID } from 'class-validator';
+
+import { PaginationOptionDto } from '#/common/dto/pagination.dto';
+
+export class RequestWordRelatedSearchDto extends PaginationOptionDto {
+	@IsString()
+	@IsAlpha()
+	@ApiProperty({
+		description: '입력한 단어 키워드',
+	})
+	keyword: string;
+}
+
+export class ResponseWordRelatedSearchDto {
+	@IsUUID()
+	@Expose()
+	id: string;
+
+	@IsString()
+	name: string;
+
+	@IsString()
+	@Transform(({ value }) => value[0])
+	diacritic: string;
+}

--- a/src/word/word.controller.ts
+++ b/src/word/word.controller.ts
@@ -33,6 +33,7 @@ import {
 	ResponseWordUserLikeDto,
 } from './dto/word-user-like.dto';
 import { WordService } from './word.service';
+import { RequestWordRelatedSearchDto, ResponseWordRelatedSearchDto } from './dto/word-related-search.dto';
 
 @ApiTags('Word')
 @Controller('word')
@@ -84,6 +85,21 @@ export class WordController {
 			userId: user.id,
 		});
 		return await this.wordService.getWordUserLike(wordUserLikeDto);
+	}
+
+	@ApiDocs({
+		summary: '특정 키워드와 연관된 단어 목록을 조회합니다.',
+		response: {
+			statusCode: HttpStatus.OK,
+			schema: ResponseWordRelatedSearchDto,
+			isPaginated: true
+		},
+	})
+	@Get('/search/related')
+	async findByRelatedSearch(
+		@Query() requestWordRelatedSearchDto: RequestWordRelatedSearchDto,
+	) {
+		return await this.wordService.getWordByRelatedKeyword(requestWordRelatedSearchDto);
 	}
 
 	@ApiDocs({

--- a/src/word/word.service.ts
+++ b/src/word/word.service.ts
@@ -15,6 +15,10 @@ import {
 } from './dto/word-detail.dto';
 import { RequestWordListDto, ResponseWordListDto } from './dto/word-list.dto';
 import {
+	RequestWordRelatedSearchDto,
+	ResponseWordRelatedSearchDto,
+} from './dto/word-related-search.dto';
+import {
 	RequestWordSearchDto,
 	ResponseWordSearchDto,
 } from './dto/word-search.dto';
@@ -176,5 +180,26 @@ export class WordService {
 		);
 
 		return new PaginationDto(responseWordSearchDto, paginationMeta);
+	}
+
+	async getWordByRelatedKeyword(
+		requestWordRelatedSearchDto: RequestWordRelatedSearchDto,
+	) {
+		const { words, totalCount } =
+			await this.wordRepository.findByRelatedSearchWord(
+				requestWordRelatedSearchDto,
+			);
+
+		const paginationMeta = new PaginationMetaDto({
+			paginationOption: requestWordRelatedSearchDto,
+			totalCount,
+		});
+
+		const responseWordRelatedSearchDto = plainToInstance(
+			ResponseWordRelatedSearchDto,
+			words,
+		);
+
+		return new PaginationDto(responseWordRelatedSearchDto, paginationMeta);
 	}
 }


### PR DESCRIPTION
## Task Summary ✨
- 단어 검색 실시간 목록 제공 API 추가

## Description 📑
- 특정 키워드를 입력할 경우 실시간으로 연관된 단어 목록을 제공하는 API 를 개설했습니다 (`/word/related`)
- 검색 결과 제공 API 과는 다르게 단어 ID, 단어 명, 단어 발음 기호만을 Pagination 형식으로 제공합니다.

## Self Checklist ✅
- [x] 코드 리뷰 요청
- [x] PR 제목 컨벤션에 맞는지 확인
- [x] PR Label 설정