### PR TITLE
[DEV-58] RefreshToken 을 기반으로 AccessToken 을 재발급하는 API 추가

### DIFF
--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -3,12 +3,13 @@ import {
 	Get,
 	HttpStatus,
 	Patch,
+	Req,
 	Res,
 	UseGuards,
 } from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
 
-import type { Response } from 'express';
+import type { Request, Response } from 'express';
 
 import { ApiDocs } from '#/common/decorators/swagger.decorator';
 import { ResponseUserInformationDto } from '#/user/dto/user-information.dto';
@@ -16,7 +17,6 @@ import { UserService } from '#/user/user.service';
 
 import { AuthService } from './auth.service';
 import { AuthenticatedUser } from './decorator/auth.decorator';
-import { AuthenticationGuard } from './guard/auth.guard';
 import { KakaoAuthGuard } from './guard/kakao-auth.guard';
 import { KakaoAuthUser } from './interface/kakao-auth.interface';
 
@@ -70,10 +70,13 @@ export class AuthController {
 			required: true,
 		},
 	})
-	@UseGuards(AuthenticationGuard)
 	@Patch('reissue')
-	async reIssueAccessToken() {
-		// NOTE : Access Token 자동 재발급의 경우 AuthenticationGuard 에서 처리
-		return true;
+	async reIssueAccessToken(
+		@Req() request: Request,
+		@Res({ passthrough: true }) response: Response,
+	) {
+		const { refreshToken } = request.cookies ?? {};
+
+		return this.authService.reIssueAccessToken(response, refreshToken);
 	}
 }

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -1,4 +1,11 @@
-import { Controller, Get, HttpStatus, Res, UseGuards } from '@nestjs/common';
+import {
+	Controller,
+	Get,
+	HttpStatus,
+	Patch,
+	Res,
+	UseGuards,
+} from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
 
 import type { Response } from 'express';
@@ -9,6 +16,7 @@ import { UserService } from '#/user/user.service';
 
 import { AuthService } from './auth.service';
 import { AuthenticatedUser } from './decorator/auth.decorator';
+import { AuthenticationGuard } from './guard/auth.guard';
 import { KakaoAuthGuard } from './guard/kakao-auth.guard';
 import { KakaoAuthUser } from './interface/kakao-auth.interface';
 
@@ -51,5 +59,21 @@ export class AuthController {
 		);
 
 		return user;
+	}
+
+	@ApiDocs({
+		summary: 'Refresh Token 을 기반으로 Access Token 을 재발급 합니다.',
+		headers: {
+			name: 'Cookie',
+			description:
+				'Refresh Token 이 담긴 Cookie 입니다. 형식은 refreshToken=[유저가 발급받은 Refresh Token] 입니다.',
+			required: true,
+		},
+	})
+	@UseGuards(AuthenticationGuard)
+	@Patch('reissue')
+	async reIssueAccessToken() {
+		// NOTE : Access Token 자동 재발급의 경우 AuthenticationGuard 에서 처리
+		return true;
 	}
 }

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -70,10 +70,21 @@ export class AuthService {
 				reIssueAccessToken,
 				reIssueRefreshToken,
 			);
+
 			return userId;
 		} catch (error) {
 			this.removeAuthenticateCookie(response);
 		}
+	}
+
+	async reIssueAccessToken(response: Response, refreshToken: string) {
+		const userId = await this.verifyAuthenticateToken(refreshToken);
+		const { accessToken: reIssueAccessToken } =
+			this.getAuthenticateToken(userId);
+
+		this.setAccessTokenInCookie(response, reIssueAccessToken);
+
+		return userId;
 	}
 
 	setAuthenticateCookie(
@@ -81,13 +92,21 @@ export class AuthService {
 		accessToken: string,
 		refreshToken: string,
 	) {
+		this.setAccessTokenInCookie(response, accessToken);
+		this.setRefreshInCookie(response, refreshToken);
+	}
+
+	private setAccessTokenInCookie(response: Response, accessToken: string) {
 		response.cookie('accessToken', accessToken, {
 			...this.cookieOption,
 			maxAge: this.ACCESS_TOKEN_MAX_AGE,
 		});
+	}
+
+	private setRefreshInCookie(response: Response, refreshToken: string) {
 		response.cookie('refreshToken', refreshToken, {
 			...this.cookieOption,
-			maxAge: this.REFRESH_TOKEN_MAX_AGE,
+			maxAge: this.ACCESS_TOKEN_MAX_AGE,
 		});
 	}
 

--- a/src/quiz/quiz.service.ts
+++ b/src/quiz/quiz.service.ts
@@ -2,7 +2,7 @@ import {
 	BadRequestException,
 	Injectable,
 	InternalServerErrorException,
-	NotFoundException
+	NotFoundException,
 } from '@nestjs/common';
 import { Cron, CronExpression } from '@nestjs/schedule';
 
@@ -130,11 +130,13 @@ export class QuizService {
 
 		const [isValidCorrectWords, isValidIncorrectWords] = await Promise.all([
 			this.wordRepository.checkIsExistsByIdList(correctWordIds),
-			this.wordRepository.checkIsExistsByIdList(incorrectWordIds)
-		])
+			this.wordRepository.checkIsExistsByIdList(incorrectWordIds),
+		]);
 
 		if (!isValidCorrectWords || !isValidIncorrectWords) {
-			throw new BadRequestException('단어 목록 중에 유효하지 않은 ID 가 있습니다.')
+			throw new BadRequestException(
+				'단어 목록 중에 유효하지 않은 ID 가 있습니다.',
+			);
 		}
 
 		const createdQuizResult =

--- a/src/word/word.controller.ts
+++ b/src/word/word.controller.ts
@@ -25,6 +25,10 @@ import {
 } from './dto/word-detail.dto';
 import { RequestWordListDto, ResponseWordListDto } from './dto/word-list.dto';
 import {
+	RequestWordRelatedSearchDto,
+	ResponseWordRelatedSearchDto,
+} from './dto/word-related-search.dto';
+import {
 	RequestWordSearchDto,
 	ResponseWordSearchDto,
 } from './dto/word-search.dto';
@@ -33,7 +37,6 @@ import {
 	ResponseWordUserLikeDto,
 } from './dto/word-user-like.dto';
 import { WordService } from './word.service';
-import { RequestWordRelatedSearchDto, ResponseWordRelatedSearchDto } from './dto/word-related-search.dto';
 
 @ApiTags('Word')
 @Controller('word')
@@ -92,14 +95,16 @@ export class WordController {
 		response: {
 			statusCode: HttpStatus.OK,
 			schema: ResponseWordRelatedSearchDto,
-			isPaginated: true
+			isPaginated: true,
 		},
 	})
 	@Get('/search/related')
 	async findByRelatedSearch(
 		@Query() requestWordRelatedSearchDto: RequestWordRelatedSearchDto,
 	) {
-		return await this.wordService.getWordByRelatedKeyword(requestWordRelatedSearchDto);
+		return await this.wordService.getWordByRelatedKeyword(
+			requestWordRelatedSearchDto,
+		);
 	}
 
 	@ApiDocs({


### PR DESCRIPTION
## Task Summary ✨
RefreshToken 을 기반으로 AccessToken 을 재발급하는 API 추가

## Description 📑
- 유저가 Cookie 에 보유한 Refresh Token 을 기반으로 새로운 Access Token 를 발급하는 로직을 추가했습니다.
- 쿠키 발급 로직을 authService 내에서 세분화했으며, 내부에서 Cookie 세팅에 필요한 로직을 사용하도록 수정했습니다.


## Self Checklist ✅
- [x] 코드 리뷰 요청
- [x] PR 제목 컨벤션에 맞는지 확인
- [x] PR Label 설정