### PR TITLE
[DEV-78] 유저 로그아웃 및 회원탈퇴 API 추가

### DIFF
--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -1,5 +1,6 @@
 import {
 	Controller,
+	Delete,
 	Get,
 	HttpStatus,
 	Patch,
@@ -19,6 +20,7 @@ import { AuthService } from './auth.service';
 import { AuthenticatedUser } from './decorator/auth.decorator';
 import { KakaoAuthGuard } from './guard/kakao-auth.guard';
 import { KakaoAuthUser } from './interface/kakao-auth.interface';
+import { AuthenticationGuard } from './guard/auth.guard';
 
 @ApiTags('Auth')
 @Controller('auth')
@@ -59,6 +61,24 @@ export class AuthController {
 		);
 
 		return user;
+	}
+
+	@ApiDocs({
+		summary: '유저의 로그아웃을 진행합니다.',
+		headers: {
+			name: 'Cookie',
+			description:
+				'서버로부터 발급 받은 AccessToken 과 RefreshToken 이 필요합니다.',
+			required: true,
+		},
+	})
+	@UseGuards(AuthenticationGuard)
+	@Delete('logout')
+	async logout(
+		@Res({ passthrough: true }) response: Response,
+	) {
+		this.authService.removeAuthenticateCookie(response);
+		return true;
 	}
 
 	@ApiDocs({

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -18,9 +18,9 @@ import { UserService } from '#/user/user.service';
 
 import { AuthService } from './auth.service';
 import { AuthenticatedUser } from './decorator/auth.decorator';
+import { AuthenticationGuard } from './guard/auth.guard';
 import { KakaoAuthGuard } from './guard/kakao-auth.guard';
 import { KakaoAuthUser } from './interface/kakao-auth.interface';
-import { AuthenticationGuard } from './guard/auth.guard';
 
 @ApiTags('Auth')
 @Controller('auth')
@@ -74,9 +74,7 @@ export class AuthController {
 	})
 	@UseGuards(AuthenticationGuard)
 	@Delete('logout')
-	async logout(
-		@Res({ passthrough: true }) response: Response,
-	) {
+	async logout(@Res({ passthrough: true }) response: Response) {
 		this.authService.removeAuthenticateCookie(response);
 		return true;
 	}

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -25,7 +25,7 @@ export class AuthService {
 		secure: true,
 		sameSite: 'none',
 		path: '/',
-		domain: '.dev-malssami.site'
+		domain: '.dev-malssami.site',
 	} as const;
 
 	private readonly ACCESS_TOKEN_MAX_AGE = 5 * 60 * 1000;

--- a/src/databases/repositories/user.repository.ts
+++ b/src/databases/repositories/user.repository.ts
@@ -25,7 +25,7 @@ export class UserRepository {
 			.getExists();
 	}
 
-	deleteById(user: User) {
+	deleteOne(user: User) {
 		return this.userRepository.softRemove(user);
 	}
 

--- a/src/databases/repositories/user.repository.ts
+++ b/src/databases/repositories/user.repository.ts
@@ -30,7 +30,16 @@ export class UserRepository {
 	}
 
 	findById(userId: string) {
-		return this.userRepository.findOne({ where: { id: userId } });
+		return this.userRepository.findOne({
+			where: { id: userId },
+		});
+	}
+
+	findByIdWithLikeRelation(userId: string) {
+		return this.userRepository.findOne({
+			where: { id: userId },
+			relations: ['likes'],
+		});
 	}
 
 	findByIdWithLikeCount(userId: string) {

--- a/src/databases/repositories/user.repository.ts
+++ b/src/databases/repositories/user.repository.ts
@@ -25,6 +25,10 @@ export class UserRepository {
 			.getExists();
 	}
 
+	deleteById(user: User) {
+		return this.userRepository.softRemove(user);
+	}
+
 	findById(userId: string) {
 		return this.userRepository.findOne({ where: { id: userId } });
 	}

--- a/src/user/user.controller.ts
+++ b/src/user/user.controller.ts
@@ -51,6 +51,7 @@ export class UserController {
 		},
 	})
 	@Get(':userId')
+	@UseGuards(AuthenticationGuard)
 	getUserInformation(
 		@Param('userId') userId: string,
 	) {
@@ -65,6 +66,7 @@ export class UserController {
 			description: '탈퇴를 진행할 유저 ID',
 		},
 	})
+	@UseGuards(AuthenticationGuard)
 	@Delete(':userId')
 	unregisterUser(
 		@Param('userId') userId: string,
@@ -75,6 +77,7 @@ export class UserController {
 	@ApiDocs({
 		summary: '특정 ID 를 가진 유저의 닉네임을 수정합니다',
 	})
+	@UseGuards(AuthenticationGuard)
 	@Patch('/nickname')
 	patchChangeNickname(
 		@Body() requestChangeNicknameDto: RequestChangeNicknameDto,

--- a/src/user/user.controller.ts
+++ b/src/user/user.controller.ts
@@ -1,6 +1,7 @@
 import {
 	Body,
 	Controller,
+	Delete,
 	Get,
 	HttpStatus,
 	Param,
@@ -52,6 +53,26 @@ export class UserController {
 	})
 	@Get(':userId')
 	getUserInformation(
+		@Param('userId', new ParseUUIDPipe({ version: undefined }))
+		userId: string,
+	) {
+		return this.userService.getUserInformation(userId);
+	}
+
+	@ApiDocs({
+		summary: '유저를 조회한 후 회원탈퇴를 진행합니다.',
+		params: {
+			name: 'userId',
+			required: true,
+			description: '탈퇴를 진행할 유저 UUID (id)',
+		},
+		response: {
+			statusCode: HttpStatus.OK,
+			schema: Boolean,
+		},
+	})
+	@Delete(':userId')
+	unregisterUser(
 		@Param('userId', new ParseUUIDPipe({ version: undefined }))
 		userId: string,
 	) {

--- a/src/user/user.controller.ts
+++ b/src/user/user.controller.ts
@@ -5,7 +5,6 @@ import {
 	Get,
 	HttpStatus,
 	Param,
-	ParseUUIDPipe,
 	Patch,
 	UseGuards,
 } from '@nestjs/common';
@@ -44,7 +43,7 @@ export class UserController {
 		params: {
 			name: 'userId',
 			required: true,
-			description: '조회할 유저 UUID (id)',
+			description: '정보를 조회할 유저 ID',
 		},
 		response: {
 			statusCode: HttpStatus.OK,
@@ -53,8 +52,7 @@ export class UserController {
 	})
 	@Get(':userId')
 	getUserInformation(
-		@Param('userId', new ParseUUIDPipe({ version: undefined }))
-		userId: string,
+		@Param('userId') userId: string,
 	) {
 		return this.userService.getUserInformation(userId);
 	}
@@ -64,19 +62,14 @@ export class UserController {
 		params: {
 			name: 'userId',
 			required: true,
-			description: '탈퇴를 진행할 유저 UUID (id)',
-		},
-		response: {
-			statusCode: HttpStatus.OK,
-			schema: Boolean,
+			description: '탈퇴를 진행할 유저 ID',
 		},
 	})
 	@Delete(':userId')
 	unregisterUser(
-		@Param('userId', new ParseUUIDPipe({ version: undefined }))
-		userId: string,
+		@Param('userId') userId: string,
 	) {
-		return this.userService.getUserInformation(userId);
+		return this.userService.removeUserInformation(userId);
 	}
 
 	@ApiDocs({

--- a/src/user/user.controller.ts
+++ b/src/user/user.controller.ts
@@ -52,9 +52,7 @@ export class UserController {
 	})
 	@Get(':userId')
 	@UseGuards(AuthenticationGuard)
-	getUserInformation(
-		@Param('userId') userId: string,
-	) {
+	getUserInformation(@Param('userId') userId: string) {
 		return this.userService.getUserInformation(userId);
 	}
 
@@ -68,9 +66,7 @@ export class UserController {
 	})
 	@UseGuards(AuthenticationGuard)
 	@Delete(':userId')
-	unregisterUser(
-		@Param('userId') userId: string,
-	) {
+	unregisterUser(@Param('userId') userId: string) {
 		return this.userService.removeUserInformation(userId);
 	}
 

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -1,4 +1,4 @@
-import { BadRequestException, Injectable } from '@nestjs/common';
+import { BadRequestException, Injectable, InternalServerErrorException } from '@nestjs/common';
 
 import { plainToInstance } from 'class-transformer';
 
@@ -37,6 +37,23 @@ export class UserService {
 		);
 
 		return responseUserInformationDto;
+	}
+
+	async removeUserInformation(userId: string) {
+		const user =
+			await this.userRepository.findById(userId);
+
+		if (!user) {
+			throw new BadRequestException('존재하지 않는 유저입니다');
+		}
+
+		const deleteResult = await this.userRepository.deleteOne(user);
+
+		if (!deleteResult) {
+			throw new InternalServerErrorException('유저 정보가 정상적으로 삭제되지 않았습니다.')
+		}
+
+		return true;
 	}
 
 	async changeUserNickname(changeNickNameDto: RequestChangeNicknameDto) {

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -41,7 +41,7 @@ export class UserService {
 
 	async removeUserInformation(userId: string) {
 		const user =
-			await this.userRepository.findById(userId);
+			await this.userRepository.findByIdWithLikeRelation(userId);
 
 		if (!user) {
 			throw new BadRequestException('존재하지 않는 유저입니다');

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -1,4 +1,8 @@
-import { BadRequestException, Injectable, InternalServerErrorException } from '@nestjs/common';
+import {
+	BadRequestException,
+	Injectable,
+	InternalServerErrorException,
+} from '@nestjs/common';
 
 import { plainToInstance } from 'class-transformer';
 
@@ -40,8 +44,7 @@ export class UserService {
 	}
 
 	async removeUserInformation(userId: string) {
-		const user =
-			await this.userRepository.findByIdWithLikeRelation(userId);
+		const user = await this.userRepository.findByIdWithLikeRelation(userId);
 
 		if (!user) {
 			throw new BadRequestException('존재하지 않는 유저입니다');
@@ -50,7 +53,9 @@ export class UserService {
 		const deleteResult = await this.userRepository.deleteOne(user);
 
 		if (!deleteResult) {
-			throw new InternalServerErrorException('유저 정보가 정상적으로 삭제되지 않았습니다.')
+			throw new InternalServerErrorException(
+				'유저 정보가 정상적으로 삭제되지 않았습니다.',
+			);
 		}
 
 		return true;

--- a/src/word/word.controller.ts
+++ b/src/word/word.controller.ts
@@ -130,7 +130,8 @@ export class WordController {
 	}
 
 	@ApiDocs({
-		summary: '특정 단어의 상세 정보를 ID 혹은 이름으로 검색하여 열람합니다.',
+		summary:
+			'특정 단어의 상세 정보를 ID 혹은 이름으로 검색하여 열람합니다.',
 		response: {
 			statusCode: HttpStatus.OK,
 			schema: ResponseWordDetailDto,


### PR DESCRIPTION
## Task Summary ✨
유저 로그아웃 및 회원탈퇴 API 추가

## Description 📑
- 유저 로그아웃 API 를 개설하고, 세팅된 Cookie 를 제거하는 Service 로직을 호출하도록 적용했습니다.
- 유저 회원탈퇴 API 를 개설하고 추후 복구 요청이 들어올 가능성을 염두하여 SoftRemove를 적용했습니다.
- 유저 회원탈퇴 시 유저가 추가한 Like 도 일괄 삭제되도록 CASCASE 옵션을 점검했습니다.

## More Information 🛎
- `CASCADE` 옵션을 잘 설정했더라도 SoftRemove 에 들어가는 Entity 에 Relation 이 없으면 동작하지 않았다.
- 따라서 **findByIdWithLikeRelation** 이라는 메서드를 별도로 추가했는데 이렇게 관리해도 괜찮은지 의문이 좀 든다.

## Self Checklist ✅
- [x] PR 제목 컨벤션에 맞는지 확인
- [x] PR Label 설정