### PR TITLE
[DEV-89] 회원 탈퇴 시 쿠키가 만료되지 않는 문제 수정

### DIFF
--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -24,6 +24,7 @@ export class AuthService {
 	private cookieOption = {
 		secure: true,
 		sameSite: 'none',
+		httpOnly: true,
 		path: '/',
 		domain: '.dev-malssami.site',
 	} as const;

--- a/src/user/user.controller.ts
+++ b/src/user/user.controller.ts
@@ -6,10 +6,14 @@ import {
 	HttpStatus,
 	Param,
 	Patch,
+	Res,
 	UseGuards,
 } from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
 
+import type { Response } from 'express';
+
+import { AuthService } from '#/auth/auth.service';
 import { AuthenticatedUser } from '#/auth/decorator/auth.decorator';
 import { AuthenticationGuard } from '#/auth/guard/auth.guard';
 import { ApiDocs } from '#/common/decorators/swagger.decorator';
@@ -22,7 +26,10 @@ import { UserService } from './user.service';
 @ApiTags('User')
 @Controller('user')
 export class UserController {
-	constructor(private readonly userService: UserService) {}
+	constructor(
+		private readonly userService: UserService,
+		private readonly authService: AuthService,
+	) {}
 
 	@ApiDocs({
 		summary: '자기 자신의 유저 정보를 열람합니다',
@@ -66,7 +73,11 @@ export class UserController {
 	})
 	@UseGuards(AuthenticationGuard)
 	@Delete(':userId')
-	unregisterUser(@Param('userId') userId: string) {
+	unregisterUser(
+		@Param('userId') userId: string,
+		@Res({ passthrough: true }) response: Response,
+	) {
+		this.authService.removeAuthenticateCookie(response);
 		return this.userService.removeUserInformation(userId);
 	}
 


### PR DESCRIPTION
## Task Summary ✨
회원 탈퇴 시 쿠키가 만료되지 않는 문제 해결

## Description 📑
회원탈퇴 API 가 호출된 이후 Cookie 를 삭제하는 로직을 호출하도록 수정
Cookie 설정 시 HttpOnly 옵션을 true 로 걸도록 수정

## Self Checklist ✅
- [x] PR 제목 컨벤션에 맞는지 확인
- [x] PR Label 설정