### PR TITLE
[DEV-92] 회원탈퇴 이전 설문조사 응답을 SpreadSheet 에 저장하는 API 개설

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -18,6 +18,7 @@ import { DiscordWebhookModule } from './discord/discord.module';
 import { LikeModule } from './like/like.module';
 import { QuizModule } from './quiz/quiz.module';
 import { RedisModule } from './redis/redis.module';
+import { ResearchModule } from './research/research.module';
 import { UserModule } from './user/user.module';
 import { WordModule } from './word/word.module';
 
@@ -39,6 +40,7 @@ import { WordModule } from './word/word.module';
 		WordModule,
 		LikeModule,
 		QuizModule,
+		ResearchModule,
 	],
 	controllers: [AppController],
 	providers: [Logger],

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -31,7 +31,7 @@ import { WordModule } from './word/word.module';
 		TypeOrmModule.forRootAsync({
 			useClass: TypeOrmConfig,
 		}),
-		RedisModule.forRootAsync(),
+		// RedisModule.forRootAsync(),
 		WinstonLoggerModule,
 		ScheduleModule.forRoot(),
 		DiscordWebhookModule,

--- a/src/research/dto/research-before-quit.dto.ts
+++ b/src/research/dto/research-before-quit.dto.ts
@@ -1,24 +1,25 @@
-import { ApiProperty } from "@nestjs/swagger";
-import { IsNotEmpty, IsOptional, IsString } from "class-validator";
+import { ApiProperty } from '@nestjs/swagger';
+
+import { IsNotEmpty, IsOptional, IsString } from 'class-validator';
 
 export class RequestResearchBeforeQuitDto {
 	@IsString()
 	userId: string;
 
-    @IsString()
+	@IsString()
 	userName: string;
 
-    @IsString()
-    @IsNotEmpty()
+	@IsString()
+	@IsNotEmpty()
 	@ApiProperty({
 		description: '첫번째 객관식 질문에 대해 유저가 선택한 답변',
 	})
-    question1: string;
+	question1: string;
 
-    @IsString()
-    @IsOptional()
-    @ApiProperty({
+	@IsString()
+	@IsOptional()
+	@ApiProperty({
 		description: '두번째 객관식 질문에 대해 유저가 작성한 답변',
 	})
-    question2?: string;
+	question2?: string;
 }

--- a/src/research/dto/research-before-quit.dto.ts
+++ b/src/research/dto/research-before-quit.dto.ts
@@ -1,5 +1,5 @@
 import { ApiProperty } from "@nestjs/swagger";
-import { IsNotEmpty, IsString } from "class-validator";
+import { IsNotEmpty, IsOptional, IsString } from "class-validator";
 
 export class RequestResearchBeforeQuitDto {
 	@IsString()
@@ -16,9 +16,9 @@ export class RequestResearchBeforeQuitDto {
     question1: string;
 
     @IsString()
-    @IsNotEmpty()
+    @IsOptional()
     @ApiProperty({
 		description: '두번째 객관식 질문에 대해 유저가 작성한 답변',
 	})
-    question2: string;
+    question2?: string;
 }

--- a/src/research/dto/research-before-quit.dto.ts
+++ b/src/research/dto/research-before-quit.dto.ts
@@ -1,0 +1,24 @@
+import { ApiProperty } from "@nestjs/swagger";
+import { IsNotEmpty, IsString } from "class-validator";
+
+export class RequestResearchBeforeQuitDto {
+	@IsString()
+	userId: string;
+
+    @IsString()
+	userName: string;
+
+    @IsString()
+    @IsNotEmpty()
+	@ApiProperty({
+		description: '첫번째 객관식 질문에 대해 유저가 선택한 답변',
+	})
+    question1: string;
+
+    @IsString()
+    @IsNotEmpty()
+    @ApiProperty({
+		description: '두번째 객관식 질문에 대해 유저가 작성한 답변',
+	})
+    question2: string;
+}

--- a/src/research/research.controller.ts
+++ b/src/research/research.controller.ts
@@ -1,0 +1,50 @@
+import { Body, Controller, HttpStatus, Post, UseGuards } from '@nestjs/common';
+import { ApiTags } from '@nestjs/swagger';
+
+import { plainToInstance } from 'class-transformer';
+
+import { AuthenticatedUser } from '#/auth/decorator/auth.decorator';
+import { AuthenticationGuard } from '#/auth/guard/auth.guard';
+import { ApiDocs } from '#/common/decorators/swagger.decorator';
+import { User } from '#databases/entities/user.entity';
+
+import { RequestResearchBeforeQuitDto } from './dto/research-before-quit.dto';
+import { ResearchService } from './research.service';
+
+@ApiTags('Research')
+@Controller('research')
+export class ResearchController {
+	constructor(private readonly researchService: ResearchService) {}
+
+	@ApiDocs({
+		summary: '탈퇴 전 진행하는 서비스 만족도 설문을 제출합니다.',
+		response: {
+			statusCode: HttpStatus.OK,
+			schema: Boolean,
+		},
+	})
+	@UseGuards(AuthenticationGuard)
+	@Post('/before-quit')
+	async postResearchBeforeQuit(
+		@AuthenticatedUser() user: User,
+		@Body()
+		beforeQuitRequestBody: Pick<
+			RequestResearchBeforeQuitDto,
+			'question1' | 'question2'
+		>,
+	) {
+		const requestResearchBeforeQuitDto = plainToInstance(
+			RequestResearchBeforeQuitDto,
+			{
+				userId: user.id,
+				userName: user.name,
+				...beforeQuitRequestBody,
+			},
+			{ exposeDefaultValues: true },
+		);
+
+		return await this.researchService.sendBeforeQuitResearch(
+			requestResearchBeforeQuitDto,
+		);
+	}
+}

--- a/src/research/research.controller.ts
+++ b/src/research/research.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, HttpStatus, Post, UseGuards } from '@nestjs/common';
+import { Body, Controller, Post, UseGuards } from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
 
 import { plainToInstance } from 'class-transformer';
@@ -18,9 +18,8 @@ export class ResearchController {
 
 	@ApiDocs({
 		summary: '탈퇴 전 진행하는 서비스 만족도 설문을 제출합니다.',
-		response: {
-			statusCode: HttpStatus.OK,
-			schema: Boolean,
+		body: {
+			type: RequestResearchBeforeQuitDto,
 		},
 	})
 	@UseGuards(AuthenticationGuard)

--- a/src/research/research.module.ts
+++ b/src/research/research.module.ts
@@ -1,0 +1,21 @@
+import { Module } from '@nestjs/common';
+
+import { AuthModule } from '#/auth/auth.module';
+import { SpreadSheetModule } from '#/spread-sheet/spread-sheet.module';
+import { UserModule } from '#/user/user.module';
+
+import { ResearchService } from './research.service';
+
+@Module({
+	imports: [
+		SpreadSheetModule,
+		AuthModule,
+		UserModule,
+	],
+	providers: [
+		// Service
+		ResearchService,
+	],
+	exports: [ResearchService],
+})
+export class ResearchModule {}

--- a/src/research/research.module.ts
+++ b/src/research/research.module.ts
@@ -4,15 +4,11 @@ import { AuthModule } from '#/auth/auth.module';
 import { SpreadSheetModule } from '#/spread-sheet/spread-sheet.module';
 import { UserModule } from '#/user/user.module';
 
-import { ResearchService } from './research.service';
 import { ResearchController } from './research.controller';
+import { ResearchService } from './research.service';
 
 @Module({
-	imports: [
-		SpreadSheetModule,
-		AuthModule,
-		UserModule,
-	],
+	imports: [SpreadSheetModule, AuthModule, UserModule],
 	controllers: [ResearchController],
 	providers: [
 		// Service

--- a/src/research/research.module.ts
+++ b/src/research/research.module.ts
@@ -5,6 +5,7 @@ import { SpreadSheetModule } from '#/spread-sheet/spread-sheet.module';
 import { UserModule } from '#/user/user.module';
 
 import { ResearchService } from './research.service';
+import { ResearchController } from './research.controller';
 
 @Module({
 	imports: [
@@ -12,6 +13,7 @@ import { ResearchService } from './research.service';
 		AuthModule,
 		UserModule,
 	],
+	controllers: [ResearchController],
 	providers: [
 		// Service
 		ResearchService,

--- a/src/research/research.service.ts
+++ b/src/research/research.service.ts
@@ -13,8 +13,12 @@ export class ResearchService {
 	async sendBeforeQuitResearch(
 		researchBeforeQuitDto: RequestResearchBeforeQuitDto,
 	) {
-		const { userId, userName, question1, question2 = '' } =
-			researchBeforeQuitDto;
+		const {
+			userId,
+			userName,
+			question1,
+			question2 = '',
+		} = researchBeforeQuitDto;
 
 		const appendResult = await this.spreadSheetService.appendRow({
 			sheetName: this.SPREAD_SHEET_NAME,
@@ -28,6 +32,6 @@ export class ResearchService {
 			);
 		}
 
-        return true;
+		return true;
 	}
 }

--- a/src/research/research.service.ts
+++ b/src/research/research.service.ts
@@ -1,0 +1,33 @@
+import { Injectable, InternalServerErrorException } from '@nestjs/common';
+
+import { SpreadSheetService } from '#/spread-sheet/spread-sheet.service';
+
+import { RequestResearchBeforeQuitDto } from './dto/research-before-quit.dto';
+
+@Injectable()
+export class ResearchService {
+	constructor(private readonly spreadSheetService: SpreadSheetService) {}
+
+	private readonly SPREAD_SHEET_NAME = 'researchQuit';
+
+	async sendBeforeQuitResearch(
+		researchBeforeQuitDto: RequestResearchBeforeQuitDto,
+	) {
+		const { userId, userName, question1, question2 } =
+			researchBeforeQuitDto;
+
+		const appendResult = await this.spreadSheetService.appendRow({
+			sheetName: this.SPREAD_SHEET_NAME,
+			range: `A:D`,
+			row: [[userName, userId, question1, question2]],
+		});
+
+		if (!appendResult) {
+			throw new InternalServerErrorException(
+				'SpreadSheet 에 데이터를 추가하는 과정에서 에러가 발생했습니다.',
+			);
+		}
+
+        return true;
+	}
+}

--- a/src/research/research.service.ts
+++ b/src/research/research.service.ts
@@ -13,7 +13,7 @@ export class ResearchService {
 	async sendBeforeQuitResearch(
 		researchBeforeQuitDto: RequestResearchBeforeQuitDto,
 	) {
-		const { userId, userName, question1, question2 } =
+		const { userId, userName, question1, question2 = '' } =
 			researchBeforeQuitDto;
 
 		const appendResult = await this.spreadSheetService.appendRow({

--- a/src/spread-sheet/spread-sheet.service.ts
+++ b/src/spread-sheet/spread-sheet.service.ts
@@ -110,10 +110,10 @@ export class SpreadSheetService {
 			spreadsheetId: this.spreadSheetId,
 			range: `${sheetName}-${process.env.NODE_ENV}!${range}`,
 			valueInputOption: 'USER_ENTERED',
-            insertDataOption: 'INSERT_ROWS',
+			insertDataOption: 'INSERT_ROWS',
 			requestBody: {
-                values: row,
-            },
+				values: row,
+			},
 		});
 		return response.data.updates?.updatedCells ?? 0;
 	}

--- a/src/spread-sheet/spread-sheet.service.ts
+++ b/src/spread-sheet/spread-sheet.service.ts
@@ -75,6 +75,49 @@ export class SpreadSheetService {
 		return response.data.updatedCells ?? 0;
 	}
 
+	async insertRow({
+		sheetName,
+		range,
+		value,
+	}: {
+		sheetName: string;
+		range: string;
+		value: any[][];
+	}) {
+		const sheets = this.getGoogleSheetConnect();
+		const response = await sheets.spreadsheets.values.update({
+			spreadsheetId: this.spreadSheetId,
+			range: `${sheetName}-${process.env.NODE_ENV}!${range}`,
+			valueInputOption: 'USER_ENTERED',
+			requestBody: {
+				values: value,
+			},
+		});
+		return response.data.updatedCells ?? 0;
+	}
+
+	async appendRow({
+		sheetName,
+		range,
+		row,
+	}: {
+		sheetName: string;
+		range: string;
+		row: any[][];
+	}) {
+		const sheets = this.getGoogleSheetConnect();
+		const response = await sheets.spreadsheets.values.append({
+			spreadsheetId: this.spreadSheetId,
+			range: `${sheetName}-${process.env.NODE_ENV}!${range}`,
+			valueInputOption: 'USER_ENTERED',
+            insertDataOption: 'INSERT_ROWS',
+			requestBody: {
+                values: row,
+            },
+		});
+		return response.data.updates?.updatedCells ?? 0;
+	}
+
 	async parseSpreadSheet<T extends (...args: any[]) => any>({
 		sheetName,
 		range,

--- a/src/word/dto/word-list.dto.ts
+++ b/src/word/dto/word-list.dto.ts
@@ -20,7 +20,7 @@ import {
 
 export class RequestWordListDto extends PaginationOptionDto {
 	@IsOptional()
-	@IsUUID()
+	@IsString()
 	userId?: string;
 
 	@IsOptional()


### PR DESCRIPTION
## Task Summary ✨
회원탈퇴 이전 설문조사 응답을 SpreadSheet 에 저장하는 API 개설

## Description 📑
- 회원탈퇴 이전 설문조사 응답을 SpreadSheet 에 저장하는 API 를 추가했습니다 (`/research/before-quit`)
- 여러 개의 Cell 을 특정 범주에 추가하는 Method 와 특정 데이터 목록을 시트에 Append 하는 Method 를 추가했습니다.

## Self Checklist ✅
- [x] PR 제목 컨벤션에 맞는지 확인
- [x] PR Label 설정