### PR TITLE
[DEV-105] QuizResult 에 풀이한 유저 정보도 담도록 수정

### DIFF
--- a/src/databases/repositories/quiz-result.repository.ts
+++ b/src/databases/repositories/quiz-result.repository.ts
@@ -53,7 +53,14 @@ export class QuizResultRepository {
 	async findById(quizResultId: string) {
 		return await this.quizResultRepository
 			.createQueryBuilder('quizResult')
+			.leftJoin('quizResult.user', 'user')
 			.where('quizResult.id = :quizResultId', { quizResultId })
+			.select([
+				'user.name',
+				'quizResult.id',
+				'quizResult.correctWordIds',
+				'quizResult.incorrectWordIds',
+			])
 			.getOne();
 	}
 }

--- a/src/quiz/dto/quiz-result.dto.ts
+++ b/src/quiz/dto/quiz-result.dto.ts
@@ -54,6 +54,12 @@ export class ResponseQuizResultDto {
 	@ApiProperty()
 	quizResultId: string;
 
+	@IsString()
+	@Length(6)
+	@Expose()
+	@ApiProperty()
+	userName: string;
+
 	@IsNumber()
 	@Expose()
 	@ApiProperty()

--- a/src/quiz/quiz.service.ts
+++ b/src/quiz/quiz.service.ts
@@ -201,6 +201,7 @@ export class QuizService {
 			ResponseQuizResultDto,
 			{
 				quizResultId,
+				userName: quizResult.user.name,
 				score,
 				correctWords,
 				incorrectWords,


### PR DESCRIPTION
## Task Summary ✨
QuizResult 에 풀이한 유저 정보도 담도록 수정

## Description 📑
- 생성된 퀴즈 결과 정보를 조회할 시, 해당 퀴즈를 풀이한 유저 이름도 Response DTO 에 추가되도록 수정했습니다. 
- 퀴즈 결과를 조회하는 DB Query 에서 유저 정보 및 이름도 추가로 가져오도록 수정했습니다.

## Self Checklist ✅
- [x] PR 제목 컨벤션에 맞는지 확인
- [x] PR Label 설정