### PR TITLE
[DEV-55] AdminGuard Decorator 생성 및 API 단 적용

### DIFF
--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -8,6 +8,7 @@ import { User } from '#databases/entities/user.entity';
 
 import { AuthController } from './auth.controller';
 import { AuthService } from './auth.service';
+import { AdminGuard } from './guard/admin.guard';
 import { AuthenticationGuard } from './guard/auth.guard';
 import { KakaoAuthGuard } from './guard/kakao-auth.guard';
 
@@ -25,6 +26,7 @@ import { KakaoAuthGuard } from './guard/kakao-auth.guard';
 		AuthService,
 		// Guard
 		AuthenticationGuard,
+		AdminGuard,
 		KakaoAuthGuard,
 		// Config
 		JwtConfig,

--- a/src/auth/guard/admin.guard.ts
+++ b/src/auth/guard/admin.guard.ts
@@ -1,0 +1,27 @@
+import {
+	CanActivate,
+	ExecutionContext,
+	ForbiddenException,
+	Injectable,
+} from '@nestjs/common';
+
+import { AuthService } from '#/auth/auth.service';
+
+@Injectable()
+export class AdminGuard implements CanActivate {
+	constructor(private readonly authService: AuthService) {}
+
+	async canActivate(context: ExecutionContext) {
+		const request = context.switchToHttp().getRequest();
+		const adminUser = await this.authService.checkIsAdminRequest(request);
+
+		if (!adminUser) {
+			throw new ForbiddenException(
+				'해당 요청은 어드민만 접근이 가능합니다.',
+			);
+		}
+
+		request.user = adminUser;
+		return true;
+	}
+}

--- a/src/quiz/quiz.controller.ts
+++ b/src/quiz/quiz.controller.ts
@@ -14,6 +14,7 @@ import { ApiTags } from '@nestjs/swagger';
 import { plainToInstance } from 'class-transformer';
 
 import { AuthenticatedUser } from '#/auth/decorator/auth.decorator';
+import { AdminGuard } from '#/auth/guard/admin.guard';
 import { AuthenticationGuard } from '#/auth/guard/auth.guard';
 import { ApiDocs } from '#/common/decorators/swagger.decorator';
 import { UserInformationInterceptor } from '#/user/interceptors/user-information.interceptor';
@@ -106,7 +107,7 @@ export class QuizController {
 			description: '어드민 전용 Api Key',
 		},
 	})
-	@UseGuards(AuthenticationGuard)
+	@UseGuards(AdminGuard)
 	@Patch('/selection/spread-sheet')
 	patchUpdateSpreadSheet() {
 		return this.quizService.updateQuizSelectionList();

--- a/src/word/word.controller.ts
+++ b/src/word/word.controller.ts
@@ -12,6 +12,7 @@ import { ApiTags } from '@nestjs/swagger';
 import { plainToInstance } from 'class-transformer';
 
 import { AuthenticatedUser } from '#/auth/decorator/auth.decorator';
+import { AdminGuard } from '#/auth/guard/admin.guard';
 import { AuthenticationGuard } from '#/auth/guard/auth.guard';
 import { ApiDocs } from '#/common/decorators/swagger.decorator';
 import { UserInformationInterceptor } from '#/user/interceptors/user-information.interceptor';
@@ -111,6 +112,7 @@ export class WordController {
 		},
 	})
 	@Patch('/spread-sheet')
+	@UseGuards(AdminGuard)
 	async patchUpdateSpreadSheet() {
 		return await this.wordService.updateWordList();
 	}


### PR DESCRIPTION
## Task Summary ✨
AdminGuard Decorator 생성 및 API 단 적용

## Description 📑
- AuthModule 내 Guard 에 AdminGuard 를 새롭게 생성했습니다.
- 어드민 키를 기반으로 동작해야 하는 API 2건에 대해서 Guard 를 적용했습니다.

## Self Checklist ✅
- [x] PR 제목 컨벤션에 맞는지 확인
- [x] PR Label 설정