### PR TITLE
fix: 비로그인 사용자인 경우 isLike 플래그를 false 로 반환하도록 수정

### DIFF
--- a/src/databases/repositories/word-search.repository.ts
+++ b/src/databases/repositories/word-search.repository.ts
@@ -81,7 +81,9 @@ export class WordSearchRepository {
 					'word.diacritic',
 					'word.description',
 					'word.createdAt',
-					'CASE WHEN like.id IS NOT NULL THEN true ELSE false END AS isLike',
+					userId
+						? 'CASE WHEN like.id IS NOT NULL THEN true ELSE false END AS isLike'
+						: 'false::boolean AS isLike',
 				])
 				.orderBy('word.createdAt', 'ASC')
 				.distinct(true)
@@ -90,6 +92,8 @@ export class WordSearchRepository {
 				.getRawMany(),
 			queryBuilder.getCount(),
 		]);
+
+		console.log({ words });
 
 		return { words, totalCount };
 	}

--- a/src/databases/repositories/word-search.repository.ts
+++ b/src/databases/repositories/word-search.repository.ts
@@ -93,8 +93,6 @@ export class WordSearchRepository {
 			queryBuilder.getCount(),
 		]);
 
-		console.log({ words });
-
 		return { words, totalCount };
 	}
 }

--- a/src/word-search/dto/word-search.dto.ts
+++ b/src/word-search/dto/word-search.dto.ts
@@ -82,5 +82,5 @@ export class ResponseWordSearchDto {
 		description: '유저 좋아요 여부 (비로그인 일 시 false)',
 		type: Boolean,
 	})
-	isLike: boolean;
+	isLike: boolean = false;
 }


### PR DESCRIPTION
## Task Summary ✨
비로그인 사용자인 경우 isLike 플래그를 false 로 반환하도록 수정

## Description 📑
- 비로그인 사용자가 단어 정보를 조회할 경우 Query 문제로 isLike 가 가끔 true 로 설정되는 문제 수정
- 비로그인인 경우 isLike 필드의 값을 false 로 고정하여 동일한 문제가 재발하지 않도록 수정

## Self Checklist ✅
- [x] PR 제목 컨벤션에 맞는지 확인
- [x] PR Label 설정