### PR TITLE
[DEV-190] Redis 기반 단어 별 조회수 구현 로직 개발

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
 		"redis": "^4.6.14",
 		"rxjs": "^7.8.1",
 		"typeorm": "^0.3.20",
+		"uuid": "^11.1.0",
 		"winston": "^3.13.0"
 	},
 	"devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -37,13 +37,13 @@ importers:
         version: 10.3.7(@nestjs/common@10.3.7(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@10.3.7)
       '@nestjs/schedule':
         specifier: ^4.0.2
-        version: 4.0.2(@nestjs/common@10.3.7(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@10.3.7(@nestjs/common@10.3.7(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/platform-express@10.3.7)(reflect-metadata@0.2.2)(rxjs@7.8.1))
+        version: 4.0.2(@nestjs/common@10.3.7(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@10.3.7)
       '@nestjs/swagger':
         specifier: ^7.3.1
-        version: 7.3.1(@nestjs/common@10.3.7(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@10.3.7(@nestjs/common@10.3.7(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/platform-express@10.3.7)(reflect-metadata@0.2.2)(rxjs@7.8.1))(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)
+        version: 7.3.1(@nestjs/common@10.3.7(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@10.3.7)(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)
       '@nestjs/typeorm':
         specifier: ^10.0.2
-        version: 10.0.2(@nestjs/common@10.3.7(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@10.3.7(@nestjs/common@10.3.7(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/platform-express@10.3.7)(reflect-metadata@0.2.2)(rxjs@7.8.1))(reflect-metadata@0.2.2)(rxjs@7.8.1)(typeorm@0.3.20(pg@8.11.5)(redis@4.6.14)(ts-node@10.9.2(@swc/core@1.5.25)(@types/node@20.12.7)(typescript@5.4.5)))
+        version: 10.0.2(@nestjs/common@10.3.7(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@10.3.7)(reflect-metadata@0.2.2)(rxjs@7.8.1)(typeorm@0.3.20(pg@8.11.5)(redis@4.6.14)(ts-node@10.9.2(@swc/core@1.5.25)(@types/node@20.12.7)(typescript@5.4.5)))
       axios:
         specifier: ^1.6.8
         version: 1.6.8
@@ -89,6 +89,9 @@ importers:
       typeorm:
         specifier: ^0.3.20
         version: 0.3.20(pg@8.11.5)(redis@4.6.14)(ts-node@10.9.2(@swc/core@1.5.25)(@types/node@20.12.7)(typescript@5.4.5))
+      uuid:
+        specifier: ^11.1.0
+        version: 11.1.0
       winston:
         specifier: ^3.13.0
         version: 3.13.0
@@ -101,7 +104,7 @@ importers:
         version: 10.1.1(chokidar@3.6.0)(typescript@5.4.5)
       '@nestjs/testing':
         specifier: ^10.0.0
-        version: 10.3.7(@nestjs/common@10.3.7(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@10.3.7(@nestjs/common@10.3.7(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/platform-express@10.3.7)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/platform-express@10.3.7(@nestjs/common@10.3.7(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@10.3.7))
+        version: 10.3.7(@nestjs/common@10.3.7(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@10.3.7)(@nestjs/platform-express@10.3.7)
       '@swc/cli':
         specifier: ^0.3.12
         version: 0.3.12(@swc/core@1.5.25)(chokidar@3.6.0)
@@ -4103,6 +4106,10 @@ packages:
     resolution: {integrity: sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==}
     engines: {node: '>= 0.4.0'}
 
+  uuid@11.1.0:
+    resolution: {integrity: sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==}
+    hasBin: true
+
   uuid@9.0.1:
     resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
     hasBin: true
@@ -5444,7 +5451,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@nestjs/schedule@4.0.2(@nestjs/common@10.3.7(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@10.3.7(@nestjs/common@10.3.7(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/platform-express@10.3.7)(reflect-metadata@0.2.2)(rxjs@7.8.1))':
+  '@nestjs/schedule@4.0.2(@nestjs/common@10.3.7(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@10.3.7)':
     dependencies:
       '@nestjs/common': 10.3.7(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1)
       '@nestjs/core': 10.3.7(@nestjs/common@10.3.7(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/platform-express@10.3.7)(reflect-metadata@0.2.2)(rxjs@7.8.1)
@@ -5473,7 +5480,7 @@ snapshots:
     transitivePeerDependencies:
       - chokidar
 
-  '@nestjs/swagger@7.3.1(@nestjs/common@10.3.7(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@10.3.7(@nestjs/common@10.3.7(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/platform-express@10.3.7)(reflect-metadata@0.2.2)(rxjs@7.8.1))(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)':
+  '@nestjs/swagger@7.3.1(@nestjs/common@10.3.7(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@10.3.7)(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)':
     dependencies:
       '@microsoft/tsdoc': 0.14.2
       '@nestjs/common': 10.3.7(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1)
@@ -5488,7 +5495,7 @@ snapshots:
       class-transformer: 0.5.1
       class-validator: 0.14.1
 
-  '@nestjs/testing@10.3.7(@nestjs/common@10.3.7(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@10.3.7(@nestjs/common@10.3.7(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/platform-express@10.3.7)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/platform-express@10.3.7(@nestjs/common@10.3.7(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@10.3.7))':
+  '@nestjs/testing@10.3.7(@nestjs/common@10.3.7(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@10.3.7)(@nestjs/platform-express@10.3.7)':
     dependencies:
       '@nestjs/common': 10.3.7(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1)
       '@nestjs/core': 10.3.7(@nestjs/common@10.3.7(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/platform-express@10.3.7)(reflect-metadata@0.2.2)(rxjs@7.8.1)
@@ -5496,7 +5503,7 @@ snapshots:
     optionalDependencies:
       '@nestjs/platform-express': 10.3.7(@nestjs/common@10.3.7(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@10.3.7)
 
-  '@nestjs/typeorm@10.0.2(@nestjs/common@10.3.7(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@10.3.7(@nestjs/common@10.3.7(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/platform-express@10.3.7)(reflect-metadata@0.2.2)(rxjs@7.8.1))(reflect-metadata@0.2.2)(rxjs@7.8.1)(typeorm@0.3.20(pg@8.11.5)(redis@4.6.14)(ts-node@10.9.2(@swc/core@1.5.25)(@types/node@20.12.7)(typescript@5.4.5)))':
+  '@nestjs/typeorm@10.0.2(@nestjs/common@10.3.7(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@10.3.7)(reflect-metadata@0.2.2)(rxjs@7.8.1)(typeorm@0.3.20(pg@8.11.5)(redis@4.6.14)(ts-node@10.9.2(@swc/core@1.5.25)(@types/node@20.12.7)(typescript@5.4.5)))':
     dependencies:
       '@nestjs/common': 10.3.7(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1)
       '@nestjs/core': 10.3.7(@nestjs/common@10.3.7(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/platform-express@10.3.7)(reflect-metadata@0.2.2)(rxjs@7.8.1)
@@ -9057,6 +9064,8 @@ snapshots:
   util-deprecate@1.0.2: {}
 
   utils-merge@1.0.1: {}
+
+  uuid@11.1.0: {}
 
   uuid@9.0.1: {}
 

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -22,6 +22,7 @@ import { UserRoleGuard } from '#/shared/guard/user-role';
 import { LoggerMiddleware } from '#/shared/middlewares/logger.middleware';
 
 import { AppController } from './app.controller';
+import { WordViewModule } from './domain/word-view/word-view.module';
 
 @Module({
 	imports: [
@@ -42,6 +43,7 @@ import { AppController } from './app.controller';
 		QuizModule,
 		ResearchModule,
 		WordSearchModule,
+		WordViewModule,
 		TextToSpeechModule,
 	],
 	controllers: [AppController],

--- a/src/domain/word-view/decorator/viewer-id.decorator.ts
+++ b/src/domain/word-view/decorator/viewer-id.decorator.ts
@@ -1,0 +1,36 @@
+import type { ExecutionContext } from '@nestjs/common';
+import { createParamDecorator } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+
+import { UserRole } from '#/infrastructure/drizzle/constant/user-role.constant';
+import type { RequestWithUser } from '#/shared/guard/user-role';
+
+import { USE_WORD_VIEWER_ID_INTERCEPTOR } from '../interceptor/word-viewer-id';
+import type { RequestWithViewerId } from '../interface/request-with-viewer.interface';
+
+export const ViewerId = createParamDecorator(
+	(_data: unknown, context: ExecutionContext) => {
+		const reflector = new Reflector();
+		const request = context
+			.switchToHttp()
+			.getRequest<RequestWithUser & RequestWithViewerId>();
+
+		const isWordViewerIdInterceptor = reflector.getAllAndOverride<boolean>(
+			USE_WORD_VIEWER_ID_INTERCEPTOR,
+			[context.getHandler(), context.getClass()],
+		);
+
+		if (!isWordViewerIdInterceptor) {
+			throw new Error(
+				'ViewerId 데코레이터는 UseWordViewerIdInterceptor 이후에 선언되어야 합니다.',
+			);
+		}
+
+		const viewerId =
+			request.user.role === UserRole.GUEST
+				? request.viewerId
+				: request.user.id;
+
+		return viewerId;
+	},
+);

--- a/src/domain/word-view/interceptor/word-viewer-id/index.ts
+++ b/src/domain/word-view/interceptor/word-viewer-id/index.ts
@@ -1,0 +1,2 @@
+export * from './word-viewer-id.decorator';
+export * from './word-viewer-id.interceptor';

--- a/src/domain/word-view/interceptor/word-viewer-id/word-viewer-id.decorator.ts
+++ b/src/domain/word-view/interceptor/word-viewer-id/word-viewer-id.decorator.ts
@@ -1,0 +1,14 @@
+import { SetMetadata, UseInterceptors, applyDecorators } from '@nestjs/common';
+
+import { WordViewerIdInterceptor } from './word-viewer-id.interceptor';
+
+export const USE_WORD_VIEWER_ID_INTERCEPTOR = Symbol(
+	'USE_WORD_VIEWER_ID_INTERCEPTOR',
+);
+
+export const UseWordViewerIdInterceptor = () => {
+	return applyDecorators(
+		SetMetadata(USE_WORD_VIEWER_ID_INTERCEPTOR, true),
+		UseInterceptors(WordViewerIdInterceptor),
+	);
+};

--- a/src/domain/word-view/interceptor/word-viewer-id/word-viewer-id.interceptor.ts
+++ b/src/domain/word-view/interceptor/word-viewer-id/word-viewer-id.interceptor.ts
@@ -9,7 +9,11 @@ import { Reflector } from '@nestjs/core';
 import { v4 as uuidv4 } from 'uuid';
 
 import type { RequestWithViewerId } from '#/domain/word-view/interface/request-with-viewer.interface';
-import { USE_ROLE_GUARD_KEY } from '#/shared/guard/user-role';
+import { UserRole } from '#/infrastructure/drizzle/constant/user-role.constant';
+import {
+	type RequestWithUser,
+	USE_ROLE_GUARD_KEY,
+} from '#/shared/guard/user-role';
 
 @Injectable()
 export class WordViewerIdInterceptor implements NestInterceptor {
@@ -18,7 +22,7 @@ export class WordViewerIdInterceptor implements NestInterceptor {
 	intercept(context: ExecutionContext, next: CallHandler) {
 		const request = context
 			.switchToHttp()
-			.getRequest<RequestWithViewerId>();
+			.getRequest<RequestWithViewerId & RequestWithUser>();
 		const response = context.switchToHttp().getResponse();
 
 		const isRoleGuardExists = this.reflector.getAllAndOverride<boolean>(
@@ -30,10 +34,9 @@ export class WordViewerIdInterceptor implements NestInterceptor {
 			throw new Error('Role Guard is not defined');
 		}
 
-		const accessToken = request.cookies['accessToken'];
-		const refreshToken = request.cookies['refreshToken'];
+		const isGuest = request.user?.role === UserRole.GUEST;
 
-		if (accessToken && refreshToken) {
+		if (!isGuest) {
 			return next.handle();
 		}
 

--- a/src/domain/word-view/interceptor/word-viewer-id/word-viewer-id.interceptor.ts
+++ b/src/domain/word-view/interceptor/word-viewer-id/word-viewer-id.interceptor.ts
@@ -1,0 +1,56 @@
+import type {
+	CallHandler,
+	ExecutionContext,
+	NestInterceptor,
+} from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+
+import { v4 as uuidv4 } from 'uuid';
+
+import type { RequestWithViewerId } from '#/domain/word-view/interface/request-with-viewer.interface';
+import { USE_ROLE_GUARD_KEY } from '#/shared/guard/user-role';
+
+@Injectable()
+export class WordViewerIdInterceptor implements NestInterceptor {
+	constructor(private readonly reflector: Reflector) {}
+
+	intercept(context: ExecutionContext, next: CallHandler) {
+		const request = context
+			.switchToHttp()
+			.getRequest<RequestWithViewerId>();
+		const response = context.switchToHttp().getResponse();
+
+		const isRoleGuardExists = this.reflector.getAllAndOverride<boolean>(
+			USE_ROLE_GUARD_KEY,
+			[context.getHandler(), context.getClass()],
+		);
+
+		if (!isRoleGuardExists) {
+			throw new Error('Role Guard is not defined');
+		}
+
+		const accessToken = request.cookies['accessToken'];
+		const refreshToken = request.cookies['refreshToken'];
+
+		if (accessToken && refreshToken) {
+			return next.handle();
+		}
+
+		let viewerId = request.cookies?.viewerId;
+
+		if (!viewerId) {
+			viewerId = uuidv4();
+			response.cookie('viewerId', viewerId, {
+				httpOnly: true,
+				secure: process.env.NODE_ENV === 'production',
+				maxAge: 1000 * 60 * 60 * 24 * 7,
+				sameSite: 'strict',
+			});
+		}
+
+		request.viewerId = viewerId;
+
+		return next.handle();
+	}
+}

--- a/src/domain/word-view/interface/request-with-viewer.interface.ts
+++ b/src/domain/word-view/interface/request-with-viewer.interface.ts
@@ -1,0 +1,5 @@
+import type { Request } from 'express';
+
+export interface RequestWithViewerId extends Request {
+	viewerId: string;
+}

--- a/src/domain/word-view/service/word-view.service.ts
+++ b/src/domain/word-view/service/word-view.service.ts
@@ -1,0 +1,117 @@
+import { Injectable } from '@nestjs/common';
+
+import { WordViewRepository } from '#/infrastructure/drizzle/repository/word-view.repository';
+import { InjectRedisClient } from '#/infrastructure/redis/decorator/inject-redis-client.decorator';
+import { RedisClient } from '#/infrastructure/redis/interface/redis-client.interface';
+import dayjs from '#/shared/utils/dayjs';
+import { Cron, CronExpression } from '@nestjs/schedule';
+
+@Injectable()
+export class WordViewService {
+	constructor(
+		@InjectRedisClient() private readonly redisClient: RedisClient,
+		private readonly wordViewRepository: WordViewRepository,
+	) {}
+
+	private WORD_VIEW_LOG_KEY = 'word-view-log';
+	private DUPLICATE_CHECK_THRESHOLD = 60 * 5;
+
+	private async isRecentLogExists({
+		userId,
+		wordId,
+	}: {
+		userId: string;
+		wordId: string;
+	}) {
+		const currentTimestamp = Math.floor(Date.now() / 1000);
+		const currentWordViewLogList = await this.redisClient.zRange(
+			`${this.WORD_VIEW_LOG_KEY}:${wordId}`,
+			currentTimestamp - this.DUPLICATE_CHECK_THRESHOLD,
+			currentTimestamp,
+			{ BY: 'SCORE' },
+		);
+
+		const isDuplicated = currentWordViewLogList.some((wordViewLog) =>
+			wordViewLog.includes(userId),
+		);
+		return isDuplicated;
+	}
+
+	private async getCurrentViewedWordIdList() {
+		let cursor: number = 0;
+		const wordIdList: string[] = [];
+
+		do {
+			const { cursor: nextCursor, keys } = await this.redisClient.scan(
+				cursor,
+				{ MATCH: 'word-view-log:*' },
+			);
+			const currentWordIdList = keys.map(
+				(key) => key.split(':')[1] as string,
+			);
+
+			cursor = Number(nextCursor);
+			wordIdList.push(...currentWordIdList);
+		} while (cursor !== 0);
+
+		return wordIdList;
+	}
+
+	async insertWordViewLog({
+		userId,
+		wordId,
+	}: {
+		userId: string;
+		wordId: string;
+	}) {
+		const isRecentLogExists = await this.isRecentLogExists({
+			userId,
+			wordId,
+		});
+		if (isRecentLogExists) return;
+
+		const currentTimestamp = Math.floor(Date.now() / 1000);
+		await this.redisClient.zAdd(`${this.WORD_VIEW_LOG_KEY}:${wordId}`, {
+			score: currentTimestamp,
+			value: `${userId}:${currentTimestamp}`,
+		});
+	}
+
+	private async countAndPurgeOldViewLogs({ wordId }: { wordId: string }) {
+		const LOG_PRESERVE_THRESHOLD =
+			Math.floor(Date.now() / 1000) - this.DUPLICATE_CHECK_THRESHOLD;
+
+		const viewLogAmount = await this.redisClient.zCount(
+			`${this.WORD_VIEW_LOG_KEY}:${wordId}`,
+			'-inf',
+			LOG_PRESERVE_THRESHOLD,
+		);
+
+		if (!viewLogAmount) return;
+
+		await this.redisClient.zRemRangeByScore(
+			`${this.WORD_VIEW_LOG_KEY}:${wordId}`,
+			'-inf',
+			LOG_PRESERVE_THRESHOLD,
+		);
+
+		await this.wordViewRepository.insertWordViewLog({
+			wordId,
+			viewCount: viewLogAmount,
+			viewedAt: dayjs().startOf('hours').toDate(),
+		});
+	}
+
+    @Cron(CronExpression.EVERY_3_HOURS)
+	async processBatchUpdateWordView() {
+		const wordIdList = await this.getCurrentViewedWordIdList();
+
+		if (!wordIdList.length) return;
+
+		await Promise.all(
+			wordIdList.map((wordId) =>
+				this.countAndPurgeOldViewLogs({ wordId }),
+			),
+		);
+	}
+}

--- a/src/domain/word-view/word-view.module.ts
+++ b/src/domain/word-view/word-view.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+
+import { RedisModule } from '#/infrastructure/redis/redis.module';
+
+import { WordViewerIdInterceptor } from './interceptor/word-viewer-id';
+import { WordViewService } from './service/word-view.service';
+
+@Module({
+	imports: [RedisModule],
+	providers: [WordViewService, WordViewerIdInterceptor],
+	exports: [WordViewService, WordViewerIdInterceptor],
+})
+export class WordViewModule {}

--- a/src/domain/word-view/word-view.module.ts
+++ b/src/domain/word-view/word-view.module.ts
@@ -1,5 +1,6 @@
 import { Module } from '@nestjs/common';
 
+import { WordViewRepository } from '#/infrastructure/drizzle/repository/word-view.repository';
 import { RedisModule } from '#/infrastructure/redis/redis.module';
 
 import { WordViewerIdInterceptor } from './interceptor/word-viewer-id';
@@ -7,7 +8,7 @@ import { WordViewService } from './service/word-view.service';
 
 @Module({
 	imports: [RedisModule],
-	providers: [WordViewService, WordViewerIdInterceptor],
+	providers: [WordViewService, WordViewerIdInterceptor, WordViewRepository],
 	exports: [WordViewService, WordViewerIdInterceptor],
 })
 export class WordViewModule {}

--- a/src/domain/word/word.controller.ts
+++ b/src/domain/word/word.controller.ts
@@ -3,6 +3,9 @@ import { ApiTags } from '@nestjs/swagger';
 
 import { plainToInstance } from 'class-transformer';
 
+import { ViewerId } from '#/domain/word-view/decorator/viewer-id.decorator';
+import { UseWordViewerIdInterceptor } from '#/domain/word-view/interceptor/word-viewer-id';
+import { WordViewService } from '#/domain/word-view/service/word-view.service';
 import { UserRole } from '#/infrastructure/drizzle/constant/user-role.constant';
 import { ApiDocs } from '#/shared/decorators/swagger.decorator';
 import { User } from '#/shared/decorators/user.decorator';
@@ -26,6 +29,7 @@ export class WordController {
 	constructor(
 		private readonly wordService: WordService,
 		private readonly wordUpdateBatchService: WordUpdateBatchService,
+		private readonly wordViewService: WordViewService,
 	) {}
 
 	@ApiDocs({
@@ -85,15 +89,23 @@ export class WordController {
 	})
 	@Get('/detail')
 	@UseRoleGuard(UserRole.GUEST)
+	@UseWordViewerIdInterceptor()
 	async findById(
 		@User() user: UserData<false>,
+		@ViewerId() viewerId: string,
 		@Query() requestWordDetailDto: RequestWordDetailDto,
 	) {
 		const wordDetailDto = plainToInstance(RequestWordDetailDto, {
 			userId: user.id,
 			...requestWordDetailDto,
 		});
-		return await this.wordService.getWordDetail(wordDetailDto);
+		const wordDetail = await this.wordService.getWordDetail(wordDetailDto);
+		await this.wordViewService.insertWordViewLog({
+			userId: viewerId,
+			wordId: wordDetail.id,
+		})
+
+		return wordDetail;
 	}
 
 	@ApiDocs({

--- a/src/domain/word/word.module.ts
+++ b/src/domain/word/word.module.ts
@@ -7,12 +7,20 @@ import { WordSearchRepository } from '#/infrastructure/drizzle/repository/word-s
 import { WordRepository } from '#/infrastructure/drizzle/repository/word.repository';
 import { SpreadSheetModule } from '#/infrastructure/spread-sheet/spread-sheet.module';
 
+import { WordViewModule } from '../word-view/word-view.module';
+
 import { WordUpdateBatchService } from './service/word-update-batch.service';
 import { WordService } from './service/word.service';
 import { WordController } from './word.controller';
 
 @Module({
-	imports: [SpreadSheetModule, AuthModule, UserModule, TextToSpeechModule],
+	imports: [
+		SpreadSheetModule,
+		AuthModule,
+		UserModule,
+		TextToSpeechModule,
+		WordViewModule,
+	],
 	controllers: [WordController],
 	providers: [
 		// Service

--- a/src/infrastructure/drizzle/repository/word-view.repository.ts
+++ b/src/infrastructure/drizzle/repository/word-view.repository.ts
@@ -1,0 +1,34 @@
+import { Injectable } from '@nestjs/common';
+
+import { InjectDrizzleClient } from '#/infrastructure/drizzle/decorator/inject-drizzle-client.decorator';
+import { wordView } from '#/infrastructure/drizzle/schema';
+import { DrizzlePgClient } from '../interface/drizzle-pg-client.interface';
+
+@Injectable()
+export class WordViewRepository {
+	constructor(
+		@InjectDrizzleClient()
+		private readonly db: DrizzlePgClient,
+	) {}
+
+	async insertWordViewLog({
+		wordId,
+		viewCount,
+		viewedAt,
+	}: {
+		wordId: string;
+		viewCount: number;
+		viewedAt: Date;
+	}) {
+		const [queryResult] = await this.db
+			.insert(wordView)
+			.values({
+				wordId,
+				viewCount,
+				viewedAt,
+			})
+			.returning();
+
+		return queryResult;
+	}
+}

--- a/src/infrastructure/drizzle/schema/index.ts
+++ b/src/infrastructure/drizzle/schema/index.ts
@@ -5,4 +5,5 @@ export * from './ranking.schema';
 export * from './text-to-speech.schema';
 export * from './user.schema';
 export * from './word-search.schema';
+export * from './word-view.schema';
 export * from './word.schema';

--- a/src/infrastructure/drizzle/schema/word-view.schema.ts
+++ b/src/infrastructure/drizzle/schema/word-view.schema.ts
@@ -1,0 +1,44 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+import { IsDate, IsNotEmpty, IsNumber, IsString } from 'class-validator';
+import { relations } from 'drizzle-orm';
+import { date, integer, pgTable, uuid } from 'drizzle-orm/pg-core';
+
+import { word } from './word.schema';
+
+export const wordView = pgTable('word_view', {
+	viewCount: integer().notNull(),
+	viewedAt: date({ mode: 'date' }),
+	wordId: uuid()
+		.notNull()
+		.references(() => word.id, { onDelete: 'cascade' }),
+});
+
+export const wordViewRelation = relations(wordView, ({ one }) => ({
+	word: one(word, {
+		fields: [wordView.wordId],
+		references: [word.id],
+	}),
+}));
+
+export type WordViewEntity = typeof wordView.$inferSelect;
+
+export class WordViewSchema implements WordViewEntity {
+	@IsNumber()
+	@IsNotEmpty()
+	@ApiProperty({ type: Number, required: true })
+	viewCount: number;
+
+	@IsDate()
+	@ApiProperty({
+		type: Date,
+		required: true,
+		example: '2025-01-23T13:00:00.000Z',
+	})
+	viewedAt: Date;
+
+	@IsString()
+	@IsNotEmpty()
+	@ApiProperty({ type: String, required: true, example: 'word12345' })
+	wordId: string;
+}

--- a/src/infrastructure/redis/factory/redis-client.factory.ts
+++ b/src/infrastructure/redis/factory/redis-client.factory.ts
@@ -2,9 +2,11 @@ import type { ConfigService } from '@nestjs/config';
 
 import { createClient } from 'redis';
 
+import type { RedisClient } from '../interface/redis-client.interface';
+
 export const redisConnectionFactory = async (
 	configService: ConfigService,
-): Promise<ReturnType<typeof createClient>> => {
+): Promise<RedisClient> => {
 	const REDIS_HOST = configService.getOrThrow<string>('REDIS_HOST');
 	const REDIS_PORT = configService.getOrThrow<string>('REDIS_PORT');
 	return await createClient({

--- a/src/infrastructure/redis/interface/redis-client.interface.ts
+++ b/src/infrastructure/redis/interface/redis-client.interface.ts
@@ -1,0 +1,3 @@
+import { createClient } from "redis";
+
+export type RedisClient = ReturnType<typeof createClient>;

--- a/src/shared/guard/user-role/request-with-user.interface.ts
+++ b/src/shared/guard/user-role/request-with-user.interface.ts
@@ -15,7 +15,7 @@ export interface RegisterUserData {
 }
 
 export interface RequestWithUser extends Request {
-	user?: RegisterUserData | GuestUserData;
+	user: RegisterUserData | GuestUserData;
 }
 
 export type UserData<IsAllowGuest = false> = IsAllowGuest extends true

--- a/src/shared/guard/user-role/user-role.guard.ts
+++ b/src/shared/guard/user-role/user-role.guard.ts
@@ -28,7 +28,7 @@ export class UserRoleGuard implements CanActivate {
 			[context.getHandler(), context.getClass()],
 		);
 
-		if (!requiredRole) {
+		if (requiredRole === UserRole.GUEST) {
 			return this.processGuestRole(request);
 		}
 


### PR DESCRIPTION
## Task Summary ✨
Redis 기반 단어 별 조회수 구현 로직 개발

## Description 📑
- Redis Sorted Set 자료구조에 단어 별 유저 조회 내역을 저장하고, 요청 시간 순으로 이를 정렬하도록 설정했습니다.
- 3시간 단위로 각 단어 별 조회 로그 수량을 계산하여 WordView Table 에 단어 별로 산출된 조회수 정보를 추가합니다.
- 어뷰징 방지를 위해 유저 별로 5분 이내에 동일 단어에 대한 요청을 보낸 경우 조회수가 올라가지 않도록 설정합니다.
- 비로그인의 경우 각 요청을 식별하기 위해 별도의 UUID 를 생성하고 이를 `viewerId` Cookie 에 추가하였습니다.

## More Information 🛎
- Redis Client 의 Return Type 을 추가하여 RedisClient 타입을 다른 Service 로직에서 원활하게 쓰도록 수정했습니다.
- UseRoleGuard 에서 UserRole 이 GUEST 인 경우 가상의 user 데이터를 Request 에 추가하도록 로직을 수정했습니다.

## Self Checklist ✅
- [x] PR 제목 컨벤션에 맞는지 확인
- [x] PR Label 설정